### PR TITLE
Account helper functions (generate / account)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ ALCHEMY_API_KEY="",
 DEPLOYER_PRIVATE_KEY=""
 ```
 
+You can also generate a random account / private key with `yarn generate` (and check the generated account with `yarn account`)
+
 2. Run the command below to deploy the contract to the target network. Make sure to have the funds in your deployer account to pay for the transaction.
 
 ```

--- a/package.json
+++ b/package.json
@@ -9,8 +9,10 @@
     ]
   },
   "scripts": {
+    "account": "yarn workspace @se-2/hardhat account",
     "chain": "yarn workspace @se-2/hardhat chain",
     "deploy": "yarn workspace @se-2/hardhat deploy",
+    "generate": "yarn workspace @se-2/hardhat generate",
     "hardhat:test": "yarn workspace @se-2/hardhat test",
     "start": "yarn workspace @se-2/frontend dev",
     "next:lint": "yarn workspace @se-2/frontend lint",

--- a/packages/hardhat/hardhat.config.ts
+++ b/packages/hardhat/hardhat.config.ts
@@ -38,12 +38,12 @@ const config: HardhatUserConfig = {
       url: `https://eth-mainnet.alchemyapi.io/v2/${providerApiKey}`,
       accounts: [deployerPrivateKey],
     },
-    optimisim: {
+    optimism: {
       url: `https://opt-mainnet.g.alchemy.com/v2/${providerApiKey}`,
       accounts: [deployerPrivateKey],
     },
-    optimisimKovan: {
-      url: `https://opt-kovan.g.alchemy.com/v2/${providerApiKey}`,
+    optimismGoerli: {
+      url: `https://opt-goerli.g.alchemy.com/v2/${providerApiKey}`,
       accounts: [deployerPrivateKey],
     },
     polygon: {

--- a/packages/hardhat/package.json
+++ b/packages/hardhat/package.json
@@ -2,8 +2,10 @@
   "name": "@se-2/hardhat",
   "version": "0.0.1",
   "scripts": {
+    "account": "hardhat run scripts/listAccount.ts",
     "chain": "hardhat node --network hardhat --no-deploy",
     "deploy": "hardhat deploy --export-all ../frontend/contracts/hardhat_contracts.json",
+    "generate": "hardhat run scripts/generateAccount.ts",
     "test": "REPORT_GAS=true hardhat test --network hardhat"
   },
   "devDependencies": {
@@ -17,6 +19,7 @@
     "@typechain/ethers-v5": "^10.1.0",
     "@typechain/hardhat": "^6.1.3",
     "@types/mocha": "^9.1.1",
+    "@types/qrcode": "^1",
     "chai": "^4.3.6",
     "ethers": "^5.7.1",
     "hardhat": "^2.11.2",
@@ -28,6 +31,7 @@
     "typescript": "^4.8.3"
   },
   "dependencies": {
-    "dotenv": "^16.0.3"
+    "dotenv": "^16.0.3",
+    "qrcode": "^1.5.1"
   }
 }

--- a/packages/hardhat/package.json
+++ b/packages/hardhat/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "dotenv": "^16.0.3",
+    "envfile": "^6.18.0",
     "qrcode": "^1.5.1"
   }
 }

--- a/packages/hardhat/scripts/generateAccount.ts
+++ b/packages/hardhat/scripts/generateAccount.ts
@@ -1,17 +1,41 @@
 import { ethers } from "ethers";
+import { parse, stringify } from "envfile";
+import * as fs from "fs";
+
+const envFilePath = "./.env";
+
+const setNewEnvConfig = (existingEnvConfig = {}) => {
+  console.log("👛 Generating new Wallet");
+  const randomWallet = ethers.Wallet.createRandom();
+
+  const newEnvConfig = {
+    ...existingEnvConfig,
+    DEPLOYER_PRIVATE_KEY: randomWallet.privateKey,
+  };
+
+  // Store in .env
+  fs.writeFileSync(envFilePath, stringify(newEnvConfig));
+  console.log("📄 Mnemonic/Private key saved to packages/hardhat/.env file");
+};
 
 async function main() {
   // Check if wallet exists (defined on .env) => return.
 
-  // Generate random wallet
-  console.log("👛 Generating new Wallet");
-  const randomWallet = ethers.Wallet.createRandom();
+  if (!fs.existsSync(envFilePath)) {
+    setNewEnvConfig();
+    return;
+  }
 
-  console.log("Private key", randomWallet.privateKey);
-  console.log("Mnemonic", randomWallet.mnemonic.phrase);
+  // file exists
+  const existingEnvConfig = parse(fs.readFileSync(envFilePath).toString());
+  if (existingEnvConfig.DEPLOYER_PRIVATE_KEY) {
+    console.log(
+      "⚠️ You already have a deployer account. Check the packages/hardhat/.env file"
+    );
+    return;
+  }
 
-  // Store in .env
-  console.log("📄 Mnemonic/Private key saved to packages/hardhat/.env file");
+  setNewEnvConfig(existingEnvConfig);
 }
 
 main().catch((error) => {

--- a/packages/hardhat/scripts/generateAccount.ts
+++ b/packages/hardhat/scripts/generateAccount.ts
@@ -4,6 +4,10 @@ import * as fs from "fs";
 
 const envFilePath = "./.env";
 
+/**
+ * Generate a new random private key and write it to the .env file
+ * @param existingEnvConfig
+ */
 const setNewEnvConfig = (existingEnvConfig = {}) => {
   console.log("👛 Generating new Wallet");
   const randomWallet = ethers.Wallet.createRandom();
@@ -19,14 +23,13 @@ const setNewEnvConfig = (existingEnvConfig = {}) => {
 };
 
 async function main() {
-  // Check if wallet exists (defined on .env) => return.
-
   if (!fs.existsSync(envFilePath)) {
+    // No .env file yet.
     setNewEnvConfig();
     return;
   }
 
-  // file exists
+  // .env file exists
   const existingEnvConfig = parse(fs.readFileSync(envFilePath).toString());
   if (existingEnvConfig.DEPLOYER_PRIVATE_KEY) {
     console.log(

--- a/packages/hardhat/scripts/generateAccount.ts
+++ b/packages/hardhat/scripts/generateAccount.ts
@@ -1,0 +1,20 @@
+import { ethers } from "ethers";
+
+async function main() {
+  // Check if wallet exists (defined on .env) => return.
+
+  // Generate random wallet
+  console.log("👛 Generating new Wallet");
+  const randomWallet = ethers.Wallet.createRandom();
+
+  console.log("Private key", randomWallet.privateKey);
+  console.log("Mnemonic", randomWallet.mnemonic.phrase);
+
+  // Store in .env
+  console.log("📄 Mnemonic/Private key saved to packages/hardhat/.env file");
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/hardhat/scripts/listAccount.ts
+++ b/packages/hardhat/scripts/listAccount.ts
@@ -1,0 +1,39 @@
+import { ethers, Wallet } from "ethers";
+import QRCode from "qrcode";
+import { config } from "hardhat";
+
+async function main() {
+  // Read mnemonic / private key from .env => if not => return
+  const privateKey =
+    "0x4cdb52ad027bffde212d5a8eeeeb308ee70c4add12f7a4fbba38cf5bb6eb474e";
+
+  // Get account from private key.
+  const wallet = new Wallet(privateKey);
+  const address = wallet.address;
+  console.log(
+    await QRCode.toString(address, { type: "terminal", small: true })
+  );
+  console.log("Public address:", address, "\n");
+
+  // Balance on each network
+  const availableNetworks = config.networks;
+  for (const networkName in availableNetworks) {
+    try {
+      const network = availableNetworks[networkName];
+      if (!network?.url) continue;
+
+      const provider = new ethers.providers.JsonRpcProvider(network.url);
+      const balance = await provider.getBalance(address);
+      console.log("--", networkName, "-- 📡");
+      console.log("   balance:", +ethers.utils.formatEther(balance));
+      console.log("   nonce:", +(await provider.getTransactionCount(address)));
+    } catch (e) {
+      console.log("Can't connect to network", networkName);
+    }
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/hardhat/scripts/listAccount.ts
+++ b/packages/hardhat/scripts/listAccount.ts
@@ -1,11 +1,19 @@
+import * as dotenv from "dotenv";
+dotenv.config();
 import { ethers, Wallet } from "ethers";
 import QRCode from "qrcode";
 import { config } from "hardhat";
 
 async function main() {
   // Read mnemonic / private key from .env => if not => return
-  const privateKey =
-    "0x4cdb52ad027bffde212d5a8eeeeb308ee70c4add12f7a4fbba38cf5bb6eb474e";
+  const privateKey = process.env.DEPLOYER_PRIVATE_KEY;
+
+  if (!privateKey) {
+    console.log(
+      "🚫️ You don't have a deployer account. Run `yarn generate` first"
+    );
+    return;
+  }
 
   // Get account from private key.
   const wallet = new Wallet(privateKey);
@@ -20,8 +28,9 @@ async function main() {
   for (const networkName in availableNetworks) {
     try {
       const network = availableNetworks[networkName];
+      // @ts-ignore
       if (!network?.url) continue;
-
+      // @ts-ignore
       const provider = new ethers.providers.JsonRpcProvider(network.url);
       const balance = await provider.getBalance(address);
       console.log("--", networkName, "-- 📡");

--- a/packages/hardhat/scripts/listAccount.ts
+++ b/packages/hardhat/scripts/listAccount.ts
@@ -5,7 +5,6 @@ import QRCode from "qrcode";
 import { config } from "hardhat";
 
 async function main() {
-  // Read mnemonic / private key from .env => if not => return
   const privateKey = process.env.DEPLOYER_PRIVATE_KEY;
 
   if (!privateKey) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1343,6 +1343,7 @@ __metadata:
     "@types/qrcode": ^1
     chai: ^4.3.6
     dotenv: ^16.0.3
+    envfile: ^6.18.0
     ethers: ^5.7.1
     hardhat: ^2.11.2
     hardhat-deploy: ^0.11.15
@@ -4391,6 +4392,15 @@ __metadata:
   version: 2.2.1
   resolution: "env-paths@npm:2.2.1"
   checksum: 65b5df55a8bab92229ab2b40dad3b387fad24613263d103a97f91c9fe43ceb21965cd3392b1ccb5d77088021e525c4e0481adb309625d0cb94ade1d1fb8dc17e
+  languageName: node
+  linkType: hard
+
+"envfile@npm:^6.18.0":
+  version: 6.18.0
+  resolution: "envfile@npm:6.18.0"
+  bin:
+    envfile: bin.cjs
+  checksum: 3a3762994d7b84ccf0293c1269cdfa5ea8971bdbbf7e3571fb686a6415eee2029e43d3faf36ed4222a83eaaf38fbc4fa37b3f50b77ea417ca35561e0e54059c1
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1340,12 +1340,14 @@ __metadata:
     "@typechain/ethers-v5": ^10.1.0
     "@typechain/hardhat": ^6.1.3
     "@types/mocha": ^9.1.1
+    "@types/qrcode": ^1
     chai: ^4.3.6
     dotenv: ^16.0.3
     ethers: ^5.7.1
     hardhat: ^2.11.2
     hardhat-deploy: ^0.11.15
     hardhat-gas-reporter: ^1.0.9
+    qrcode: ^1.5.1
     solidity-coverage: ^0.8.2
     ts-node: ^10.9.1
     typechain: ^8.1.0
@@ -1778,6 +1780,15 @@ __metadata:
   version: 15.7.5
   resolution: "@types/prop-types@npm:15.7.5"
   checksum: 5b43b8b15415e1f298243165f1d44390403bb2bd42e662bca3b5b5633fdd39c938e91b7fce3a9483699db0f7a715d08cef220c121f723a634972fdf596aec980
+  languageName: node
+  linkType: hard
+
+"@types/qrcode@npm:^1":
+  version: 1.5.0
+  resolution: "@types/qrcode@npm:1.5.0"
+  dependencies:
+    "@types/node": "*"
+  checksum: b0ece3834ca5ba6171132928fd1ef764772dc619b45cb4123461ee05e377ad15553a330d234c69db0d0028c6639a99429e88d99192fbba9c5ee97c23f278c48b
   languageName: node
   linkType: hard
 
@@ -8668,6 +8679,20 @@ __metadata:
   bin:
     qrcode: bin/qrcode
   checksum: a0857713d4390937900a2789d5a065700f7cf78cd760e773bf8524c0e907ff629db19c9bdd4210aac55b8eef53ec1c7bcaa2acf01f340ef049c53098388a45a0
+  languageName: node
+  linkType: hard
+
+"qrcode@npm:^1.5.1":
+  version: 1.5.1
+  resolution: "qrcode@npm:1.5.1"
+  dependencies:
+    dijkstrajs: ^1.0.1
+    encode-utf8: ^1.0.3
+    pngjs: ^5.0.0
+    yargs: ^15.3.1
+  bin:
+    qrcode: bin/qrcode
+  checksum: 842f899d95caaad2ac507408b5498be3197e1df16bc6b537b20069d2cb1330e4588b50f672ce4a9ccf01338f7c97b5732ff9b5caaa6eb2338187d3c25a973e79
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Took a different approach than SE1.

`yarn generate` will create/update the .env file with a private key.

For `yarn account` I'm using a more up to date (support with ES6 included :)) QR lib than SE1.

Also using hardhat scripts (instead of tasks)

P.S. We could also generate a mnemonic instead of a private key... but went for the private key, since hardhat.config was already using a private key.