### PR TITLE
hotfix:calling localhost node on live network

### DIFF
--- a/packages/frontend/components/useTempTestContract.tsx
+++ b/packages/frontend/components/useTempTestContract.tsx
@@ -1,13 +1,14 @@
 import { useEffect } from "react";
-import { useContractWrite, useContractRead, chain } from "wagmi";
+import { useContractRead, useContractWrite } from "wagmi";
 import { tempContract } from "~~/generated/tempContract";
 import { useAppStore } from "~~/services/store/store";
+import hardhatContracts from "../contracts/hardhat_contracts.json";
 
 // todo remove this, this is until we have contract element
 
-const testChainId = chain.hardhat.id;
+export const useTempTestContract = (currentChainId: number) => {
+  const isContractDeployed = currentChainId in hardhatContracts;
 
-export const useTempTestContract = () => {
   const tempState = useAppStore(state => state.tempSlice.tempState);
   const setTempState = useAppStore(state => state.tempSlice.setTempState);
 
@@ -19,7 +20,7 @@ export const useTempTestContract = () => {
     addressOrName: tempContract.address,
     contractInterface: tempContract.abi,
     functionName: "purpose",
-    chainId: testChainId,
+    chainId: isContractDeployed ? currentChainId : 0,
     watch: true,
     cacheOnBlock: false,
   });
@@ -30,7 +31,7 @@ export const useTempTestContract = () => {
     contractInterface: tempContract.abi,
     functionName: "setPurpose",
     args: "new purpose",
-    chainId: testChainId,
+    chainId: isContractDeployed ? currentChainId : 0,
   });
 
   useEffect(() => {

--- a/packages/frontend/pages/index.tsx
+++ b/packages/frontend/pages/index.tsx
@@ -4,9 +4,11 @@ import { useTempTestContract } from "~~/components/useTempTestContract";
 import { useAppStore } from "~~/services/store/store";
 import { Address, AddressInput, Balance } from "../components/scaffold-eth";
 import { useEffect } from "react";
+import { useNetwork } from "wagmi";
 
 const Home: NextPage = () => {
-  const tempTest = useTempTestContract();
+  const { chain } = useNetwork();
+  const tempTest = useTempTestContract(chain?.id as number);
 
   const tempState = useAppStore(state => state.tempSlice.tempState);
 


### PR DESCRIPTION
issue: https://github.com/scaffold-eth/se-2/issues/38

hook useTempTestContract usage hardcoded local chain id to read the contract ( useContractRead hook) 
which causes to polling on 127.0.0.1 on live network when connected with metamask. 
in this pr update, check deployed contract from the hardhat_config.json file and skip the useContractRead. 

assuming useTempTestContract is a temporary file. 

![2022_November_14_17-05-39](https://user-images.githubusercontent.com/22323693/201650370-cc2f3028-b81f-49a1-a1c1-ecfae23cccf7.png)
