### PR TITLE
Refetch display variables in  Debug ContractUI

### DIFF
--- a/packages/nextjs/components/scaffold-eth/Contract/ContractUI.tsx
+++ b/packages/nextjs/components/scaffold-eth/Contract/ContractUI.tsx
@@ -21,7 +21,7 @@ type TContractUIProps = {
 const ContractUI = ({ contractName }: TContractUIProps) => {
   const { chain } = useNetwork();
   const provider = useProvider();
-  const [displayVariablesRefresh, setDisplayVariablesRefresh] = useState(false);
+  const [refreshDisplayVariables, setRefreshDisplayVariables] = useState(false);
 
   let contractAddress = "";
   let contractABI = [];
@@ -40,15 +40,15 @@ const ContractUI = ({ contractName }: TContractUIProps) => {
   const displayedContractFunctions = useMemo(() => getAllContractFunctions(contract), [contract]);
 
   const contractVariablesDisplay = useMemo(() => {
-    return getContractVariablesAndNoParamsReadMethods(contract, displayedContractFunctions, displayVariablesRefresh);
-  }, [contract, displayedContractFunctions, displayVariablesRefresh]);
+    return getContractVariablesAndNoParamsReadMethods(contract, displayedContractFunctions, refreshDisplayVariables);
+  }, [contract, displayedContractFunctions, refreshDisplayVariables]);
 
   const contractMethodsDisplay = useMemo(
     () => getContractReadOnlyMethodsWithParams(contract, displayedContractFunctions),
     [contract, displayedContractFunctions],
   );
   const contractWriteMethods = useMemo(
-    () => getContractWriteMethods(contract, displayedContractFunctions, setDisplayVariablesRefresh),
+    () => getContractWriteMethods(contract, displayedContractFunctions, setRefreshDisplayVariables),
     [contract, displayedContractFunctions],
   );
 

--- a/packages/nextjs/components/scaffold-eth/Contract/ContractUI.tsx
+++ b/packages/nextjs/components/scaffold-eth/Contract/ContractUI.tsx
@@ -1,4 +1,5 @@
 import { Contract } from "ethers";
+import { useMemo, useState } from "react";
 import { useContract, useNetwork, useProvider } from "wagmi";
 import {
   getAllContractFunctions,
@@ -20,6 +21,7 @@ type TContractUIProps = {
 const ContractUI = ({ contractName }: TContractUIProps) => {
   const { chain } = useNetwork();
   const provider = useProvider();
+  const [displayVariablesRefresh, setDisplayVariablesRefresh] = useState(false);
 
   let contractAddress = "";
   let contractABI = [];
@@ -35,11 +37,20 @@ const ContractUI = ({ contractName }: TContractUIProps) => {
     signerOrProvider: provider,
   });
 
-  const displayedContractFunctions = getAllContractFunctions(contract);
+  const displayedContractFunctions = useMemo(() => getAllContractFunctions(contract), [contract]);
 
-  const contractVariablesDisplay = getContractVariablesAndNoParamsReadMethods(contract, displayedContractFunctions);
-  const contractMethodsDisplay = getContractReadOnlyMethodsWithParams(contract, displayedContractFunctions);
-  const contractWriteMethods = getContractWriteMethods(contract, displayedContractFunctions);
+  const contractVariablesDisplay = useMemo(() => {
+    return getContractVariablesAndNoParamsReadMethods(contract, displayedContractFunctions, displayVariablesRefresh);
+  }, [contract, displayedContractFunctions, displayVariablesRefresh]);
+
+  const contractMethodsDisplay = useMemo(
+    () => getContractReadOnlyMethodsWithParams(contract, displayedContractFunctions),
+    [contract, displayedContractFunctions],
+  );
+  const contractWriteMethods = useMemo(
+    () => getContractWriteMethods(contract, displayedContractFunctions, setDisplayVariablesRefresh),
+    [contract, displayedContractFunctions],
+  );
 
   if (!contractAddress) {
     return <p className="text-2xl">No Contract found !</p>;

--- a/packages/nextjs/components/scaffold-eth/Contract/DisplayVariables.tsx
+++ b/packages/nextjs/components/scaffold-eth/Contract/DisplayVariables.tsx
@@ -8,10 +8,10 @@ import { toast } from "~~/components/scaffold-eth";
 type TDisplayVariableProps = {
   functionFragment: FunctionFragment;
   contractAddress: string;
-  displayVariablesRefresh: boolean;
+  refreshDisplayVariables: boolean;
 };
 
-const DisplayVariable = ({ contractAddress, functionFragment, displayVariablesRefresh }: TDisplayVariableProps) => {
+const DisplayVariable = ({ contractAddress, functionFragment, refreshDisplayVariables }: TDisplayVariableProps) => {
   const {
     data: result,
     isFetching,
@@ -30,7 +30,7 @@ const DisplayVariable = ({ contractAddress, functionFragment, displayVariablesRe
     (async () => {
       await refetch();
     })();
-  }, [refetch, displayVariablesRefresh]);
+  }, [refetch, refreshDisplayVariables]);
 
   return (
     <div className="border-b-2 border-black space-y-1 pb-2">

--- a/packages/nextjs/components/scaffold-eth/Contract/DisplayVariables.tsx
+++ b/packages/nextjs/components/scaffold-eth/Contract/DisplayVariables.tsx
@@ -1,5 +1,5 @@
 import { FunctionFragment } from "ethers/lib/utils";
-import React from "react";
+import React, { useEffect } from "react";
 import { useContractRead } from "wagmi";
 import { tryToDisplay } from "./utilsDisplay";
 import { ArrowPathIcon } from "@heroicons/react/24/outline";
@@ -8,9 +8,10 @@ import { toast } from "~~/components/scaffold-eth";
 type TDisplayVariableProps = {
   functionFragment: FunctionFragment;
   contractAddress: string;
+  displayVariablesRefresh: boolean;
 };
 
-const DisplayVariable = ({ contractAddress, functionFragment }: TDisplayVariableProps) => {
+const DisplayVariable = ({ contractAddress, functionFragment, displayVariablesRefresh }: TDisplayVariableProps) => {
   const {
     data: result,
     isFetching,
@@ -24,6 +25,13 @@ const DisplayVariable = ({ contractAddress, functionFragment }: TDisplayVariable
       toast.error(error.message);
     },
   });
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    (async () => {
+      await refetch();
+    })();
+  }, [refetch, displayVariablesRefresh]);
 
   return (
     <div className="border-b-2 border-black space-y-1 pb-2">

--- a/packages/nextjs/components/scaffold-eth/Contract/DisplayVariables.tsx
+++ b/packages/nextjs/components/scaffold-eth/Contract/DisplayVariables.tsx
@@ -26,7 +26,6 @@ const DisplayVariable = ({ contractAddress, functionFragment, displayVariablesRe
     },
   });
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     (async () => {
       await refetch();

--- a/packages/nextjs/components/scaffold-eth/Contract/WriteOnlyFunctionForm.tsx
+++ b/packages/nextjs/components/scaffold-eth/Contract/WriteOnlyFunctionForm.tsx
@@ -21,13 +21,13 @@ const getInitialFormState = (functionFragment: FunctionFragment) => {
 type TWriteOnlyFunctionFormProps = {
   functionFragment: FunctionFragment;
   contractAddress: string;
-  setDisplayVariablesRefresh: Dispatch<SetStateAction<boolean>>;
+  setRefreshDisplayVariables: Dispatch<SetStateAction<boolean>>;
 };
 
 export const WriteOnlyFunctionForm = ({
   functionFragment,
   contractAddress,
-  setDisplayVariablesRefresh,
+  setRefreshDisplayVariables,
 }: TWriteOnlyFunctionFormProps) => {
   const [form, setForm] = useState<Record<string, any>>(() => getInitialFormState(functionFragment));
   const [txValue, setTxValue] = useState("");
@@ -76,7 +76,7 @@ export const WriteOnlyFunctionForm = ({
             },
           },
         );
-        setDisplayVariablesRefresh(prevState => !prevState);
+        setRefreshDisplayVariables(prevState => !prevState);
       } catch (e: any) {
         const message = getParsedEthersError(e);
         toast.error(message);

--- a/packages/nextjs/components/scaffold-eth/Contract/WriteOnlyFunctionForm.tsx
+++ b/packages/nextjs/components/scaffold-eth/Contract/WriteOnlyFunctionForm.tsx
@@ -1,5 +1,5 @@
 import { FunctionFragment } from "ethers/lib/utils";
-import { useState } from "react";
+import { Dispatch, SetStateAction, useState } from "react";
 import { useContractWrite, usePrepareContractWrite } from "wagmi";
 import { tryToDisplay } from "./utilsDisplay";
 import InputUI from "./InputUI";
@@ -21,9 +21,14 @@ const getInitialFormState = (functionFragment: FunctionFragment) => {
 type TWriteOnlyFunctionFormProps = {
   functionFragment: FunctionFragment;
   contractAddress: string;
+  setDisplayVariablesRefresh: Dispatch<SetStateAction<boolean>>;
 };
 
-export const WriteOnlyFunctionForm = ({ functionFragment, contractAddress }: TWriteOnlyFunctionFormProps) => {
+export const WriteOnlyFunctionForm = ({
+  functionFragment,
+  contractAddress,
+  setDisplayVariablesRefresh,
+}: TWriteOnlyFunctionFormProps) => {
   const [form, setForm] = useState<Record<string, any>>(() => getInitialFormState(functionFragment));
   const [txValue, setTxValue] = useState("");
 
@@ -71,6 +76,7 @@ export const WriteOnlyFunctionForm = ({ functionFragment, contractAddress }: TWr
             },
           },
         );
+        setDisplayVariablesRefresh(prevState => !prevState);
       } catch (e: any) {
         const message = getParsedEthersError(e);
         toast.error(message);

--- a/packages/nextjs/components/scaffold-eth/Contract/utilsContract.tsx
+++ b/packages/nextjs/components/scaffold-eth/Contract/utilsContract.tsx
@@ -5,6 +5,7 @@ import { Contract, utils } from "ethers";
 import DisplayVariable from "~~/components/scaffold-eth/Contract/DisplayVariables";
 import { ReadOnlyFunctionForm } from "./ReadOnlyFunctionForm";
 import { WriteOnlyFunctionForm } from "./WriteOnlyFunctionForm";
+import { Dispatch, SetStateAction } from "react";
 
 type GeneratedContractType = {
   address: string;
@@ -48,6 +49,7 @@ const getAllContractFunctions = (contract: Contract): FunctionFragment[] => {
 const getContractVariablesAndNoParamsReadMethods = (
   contract: Contract,
   contractMethodsAndVariables: FunctionFragment[],
+  displayVariablesRefresh: boolean,
 ): { loaded: boolean; methods: (JSX.Element | null)[] } => {
   return {
     loaded: true,
@@ -58,7 +60,12 @@ const getContractVariablesAndNoParamsReadMethods = (
         if (isQueryableWithNoParams) {
           return (
             // DV -> DisplayVariables
-            <DisplayVariable key={`DV_${fn.name}_${index}`} functionFragment={fn} contractAddress={contract.address} />
+            <DisplayVariable
+              key={`DV_${fn.name}_${index}`}
+              functionFragment={fn}
+              contractAddress={contract.address}
+              displayVariablesRefresh={displayVariablesRefresh}
+            />
           );
         }
         return null;
@@ -110,6 +117,7 @@ const getContractReadOnlyMethodsWithParams = (
 const getContractWriteMethods = (
   contract: Contract,
   contractMethodsAndVariables: FunctionFragment[],
+  setDisplayVariablesRefresh: Dispatch<SetStateAction<boolean>>,
 ): { loaded: boolean; methods: (JSX.Element | null)[] } => {
   return {
     loaded: true,
@@ -123,6 +131,7 @@ const getContractWriteMethods = (
               key={`FFW_${fn.name}_${index}`}
               functionFragment={fn}
               contractAddress={contract.address}
+              setDisplayVariablesRefresh={setDisplayVariablesRefresh}
             />
           );
         }

--- a/packages/nextjs/components/scaffold-eth/Contract/utilsContract.tsx
+++ b/packages/nextjs/components/scaffold-eth/Contract/utilsContract.tsx
@@ -49,7 +49,7 @@ const getAllContractFunctions = (contract: Contract): FunctionFragment[] => {
 const getContractVariablesAndNoParamsReadMethods = (
   contract: Contract,
   contractMethodsAndVariables: FunctionFragment[],
-  displayVariablesRefresh: boolean,
+  refreshDisplayVariables: boolean,
 ): { loaded: boolean; methods: (JSX.Element | null)[] } => {
   return {
     loaded: true,
@@ -64,7 +64,7 @@ const getContractVariablesAndNoParamsReadMethods = (
               key={`DV_${fn.name}_${index}`}
               functionFragment={fn}
               contractAddress={contract.address}
-              displayVariablesRefresh={displayVariablesRefresh}
+              refreshDisplayVariables={refreshDisplayVariables}
             />
           );
         }
@@ -117,7 +117,7 @@ const getContractReadOnlyMethodsWithParams = (
 const getContractWriteMethods = (
   contract: Contract,
   contractMethodsAndVariables: FunctionFragment[],
-  setDisplayVariablesRefresh: Dispatch<SetStateAction<boolean>>,
+  setRefreshDisplayVariables: Dispatch<SetStateAction<boolean>>,
 ): { loaded: boolean; methods: (JSX.Element | null)[] } => {
   return {
     loaded: true,
@@ -131,7 +131,7 @@ const getContractWriteMethods = (
               key={`FFW_${fn.name}_${index}`}
               functionFragment={fn}
               contractAddress={contract.address}
-              setDisplayVariablesRefresh={setDisplayVariablesRefresh}
+              setRefreshDisplayVariables={setRefreshDisplayVariables}
             />
           );
         }


### PR DESCRIPTION
### Approach taken : 
```js
  const [refreshDisplayVariables, setRefreshDisplayVariables] = useState(false);
```
created a common state(`refreshDisplayVariables`) which is shared by `WriteOnlyFunctionForm` and `DisplayVariables` component . `WriteOnlyFunctionForm`  **changes the state** and based on state changes `DisplayVariables` uses [`refetch`](https://0.6.x.wagmi.sh/docs/hooks/useContractRead#return-value) function to refetch the variables again. 

### Demo : 

https://user-images.githubusercontent.com/80153681/205015942-f6b85592-cd07-407a-965e-c32cfbb03873.mov


### Alternate approaches that can be considered : 
1) using `watch : true`  : 
This is a simple solution we can use, its just that each variable will keep making `eth_blocknumber` calls and its a bit less responsive since will be making `eth_blocknumber` after `3sec` to get new data.
2) using `queryKey`(in future if wagmi make it available) : 
As mentioned #32 we can use `key` if wagmi exposes it in future (currently its not exposed even in new version 0.8). wagmi using useQuery internally...[check this out](https://github.dev/wagmi-dev/wagmi/blob/d21a868a2d6bf31df38ff80a261456e264e5d128/packages/react/src/hooks/contracts/useContractRead.ts#L155)

### Some useful ongoing discussions on wagmi: 
1) https://github.com/wagmi-dev/wagmi/discussions/1238

### Some discussions on `refetch` which uses the same patterns as wagmi : 
1) https://github.com/apollographql/react-apollo/issues/562

