### PR TITLE
theme toggle button

### DIFF
--- a/packages/nextjs/components/Footer.tsx
+++ b/packages/nextjs/components/Footer.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { CurrencyDollarIcon } from "@heroicons/react/24/outline";
 import { useAppStore } from "~~/services/store/store";
 import { HeartIcon } from "@heroicons/react/24/outline";
+import SwitchTheme from "./SwitchTheme";
 
 /**
  * Site footer
@@ -59,7 +60,7 @@ export default function Footer() {
         </ul>
       </div>
       <div className="mr-4 text-sm">
-        <div>Color Switch Placeholder</div>
+        <SwitchTheme />
       </div>
     </div>
   );

--- a/packages/nextjs/components/SwitchTheme.tsx
+++ b/packages/nextjs/components/SwitchTheme.tsx
@@ -1,0 +1,20 @@
+//SwitchTheme.tsx
+import React, { useEffect } from "react";
+import { useDarkMode } from "usehooks-ts";
+import { SunIcon } from "@heroicons/react/24/outline";
+const SwitchTheme = () => {
+  const { isDarkMode, toggle } = useDarkMode(false);
+
+  useEffect(() => {
+    const body = document.body;
+    body.setAttribute("data-theme", isDarkMode ? "scaffoldEthDark" : "scaffoldEth");
+  }, [isDarkMode]);
+
+  return (
+    <div className="flex space-x-2">
+      <input type="checkbox" className="toggle toggle-primary bg-primary" onChange={toggle} checked={isDarkMode} />
+      <SunIcon className="swap-off h-6 w-6" />
+    </div>
+  );
+};
+export default SwitchTheme;

--- a/packages/nextjs/components/SwitchTheme.tsx
+++ b/packages/nextjs/components/SwitchTheme.tsx
@@ -1,7 +1,7 @@
-//SwitchTheme.tsx
 import React, { useEffect } from "react";
 import { useDarkMode, useIsMounted } from "usehooks-ts";
 import { MoonIcon, SunIcon } from "@heroicons/react/24/outline";
+
 const SwitchTheme = () => {
   const { isDarkMode, toggle } = useDarkMode(false);
   const isMounted = useIsMounted();

--- a/packages/nextjs/components/SwitchTheme.tsx
+++ b/packages/nextjs/components/SwitchTheme.tsx
@@ -1,9 +1,10 @@
 //SwitchTheme.tsx
 import React, { useEffect } from "react";
-import { useDarkMode } from "usehooks-ts";
-import { SunIcon } from "@heroicons/react/24/outline";
+import { useDarkMode, useIsMounted } from "usehooks-ts";
+import { MoonIcon, SunIcon } from "@heroicons/react/24/outline";
 const SwitchTheme = () => {
   const { isDarkMode, toggle } = useDarkMode(false);
+  const isMounted = useIsMounted();
 
   useEffect(() => {
     const body = document.body;
@@ -12,8 +13,19 @@ const SwitchTheme = () => {
 
   return (
     <div className="flex space-x-2">
-      <input type="checkbox" className="toggle toggle-primary bg-primary" onChange={toggle} checked={isDarkMode} />
-      <SunIcon className="swap-off h-6 w-6" />
+      <input
+        id="theme-toggle"
+        type="checkbox"
+        className="toggle toggle-primary bg-primary"
+        onChange={toggle}
+        checked={isDarkMode}
+      />
+      {isMounted() && (
+        <label htmlFor="theme-toggle" className={`swap swap-rotate ${!isDarkMode ? "swap-active" : ""}`}>
+          <SunIcon className="swap-on h-5 w-5" />
+          <MoonIcon className="swap-off h-5 w-5" />
+        </label>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
### Description 
Setted up a basic toggle button : 

https://user-images.githubusercontent.com/80153681/210176539-4d93f3e8-a611-4f96-bbc4-ad47d86e70a4.mov

### Approach : 
Utilized [`useDarkMode` ](https://usehooks-ts.com/react-hook/use-dark-mode) hook provided by usehooks-ts library. 

### Reason for not using [`theme-change`](https://github.com/saadeghi/theme-change) : 
- I felt that theme-change could have been more useful if we have had more than two themes because for only light and dark theme we have already have `useDarkMode` which takes care off cases from persisting it in localstorage to grabbing the default OS theme and setting it based on that. 
- but if we plan to have more themes then theme-change seems best for this purpose. 

### TODO : 
- [x] Currently, we can see that in the demo there is only a static `SunIcon` make it dynamic 

Fixes #79 