### PR TITLE
utils and hooks for better DX

### DIFF
--- a/packages/nextjs/hooks/scaffold-eth/index.ts
+++ b/packages/nextjs/hooks/scaffold-eth/index.ts
@@ -3,3 +3,4 @@ export * from "./useBurnerWallet";
 export * from "./useEthPrice";
 export * from "./useTransactor";
 export * from "./useOutsideClick";
+export * from "./useScaffoldRead";

--- a/packages/nextjs/hooks/scaffold-eth/useScaffoldRead.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useScaffoldRead.ts
@@ -1,0 +1,25 @@
+import { useContractRead, useNetwork } from "wagmi";
+import { getDeployedContract } from "~~/components/scaffold-eth/Contract/utilsContract";
+
+const useScaffoldRead = (
+  contractName: string,
+  functionName: string,
+  readConfig?: Omit<Parameters<typeof useContractRead>[0], "functionName">,
+) => {
+  const { chain } = useNetwork();
+  const deployedContractData = getDeployedContract(chain?.id.toString(), contractName);
+  let contractAddress = "";
+  let contractABI = [];
+  if (deployedContractData) {
+    ({ address: contractAddress, abi: contractABI } = deployedContractData);
+  }
+
+  return useContractRead({
+    ...readConfig,
+    functionName,
+    addressOrName: contractAddress,
+    contractInterface: contractABI,
+  });
+};
+
+export default useScaffoldRead;

--- a/packages/nextjs/pages/demoExample.tsx
+++ b/packages/nextjs/pages/demoExample.tsx
@@ -1,0 +1,25 @@
+import type { NextPage } from "next";
+import Spinner from "~~/components/Spinner";
+import useScaffoldRead from "~~/hooks/scaffold-eth/useScaffoldRead";
+
+const DemoExample: NextPage = () => {
+  const { data, isLoading, refetch } = useScaffoldRead("YourContract", "purpose");
+  return (
+    <div className="flex flex-col items-center justify-center">
+      <h1 className="text-2xl my-5">Example UI</h1>
+      {isLoading ? <Spinner /> : <p>{data}</p>}
+      <button
+        disabled={isLoading}
+        className="btn btn-primary"
+        onClick={async () => {
+          console.log("Refetching...");
+          await refetch();
+        }}
+      >
+        Refetch
+      </button>
+    </div>
+  );
+};
+
+export default DemoExample;


### PR DESCRIPTION
### Description 
Added a basic `useScaffoldRead` hook (to start with draft). 

### wagmi 0.6.x type inference problem
It seems that wagmi 0.6.x does not support type inference. The type inference was introduced in [wagmi 0.7.x](https://wagmi.sh/react/migration-guide#07x-breaking-changes).

### Problems faced
- I tried upgrading the version of wagmi(not in this branch) and seems like for type inference we need to generate abi's in `.ts` file. Currently we are exporting all abi's in `generated` directory as `.json` file. 
	
  > Unfortunately [TypeScript doesn't support importing JSON as const]
(https://github.com/microsoft/TypeScript/issues/32063). If you have ABIs in `.json` files, you should convert the files to `.ts`, export the ABIs, and add const assertions to them. (We have future integrations planned for Foundry/Hardhat users to make this easier.) - wagmi docs

  also while exporting we need to export it `as const`. Here is some useful discussion around this topic https://github.com/wagmi-dev/wagmi/discussions/1084#discussioncomment-3891592

### Suggestions needed 
Now to get good auto-completion and take full advantage of the typescript as mentioned in #88, I think the following are steps that we need to take : 
a. Bump the version of wagmi
b. handle the exports of abi to .ts file
c. create utility hooks and utils


1.) **I feel 1 and 2 can be conquered parallelly but should we do it in this PR itself?**

2.) **would love to hear a view on hooks like `useYourContractRead` instead of `useScaffoldRead`?**
Reason: Felt a lot of resistance to get the correct types for abi but was not able to achieve it, because it is dynamic.Also maybe because of my limited knowledge of typescript. Would love it if someone could give it a try 🙌 . 



