### PR TITLE
Grab funds tooltip

### DIFF
--- a/packages/nextjs/components/scaffold-eth/Balance.tsx
+++ b/packages/nextjs/components/scaffold-eth/Balance.tsx
@@ -1,6 +1,4 @@
-import { useEffect, useState } from "react";
-import { useBalance } from "wagmi";
-import { useAppStore } from "~~/services/store/store";
+import { useWalletBalance } from "~~/hooks/scaffold-eth/useWalletBalance";
 
 type TBalanceProps = {
   address: string;
@@ -10,29 +8,7 @@ type TBalanceProps = {
  * Display (ETH & USD) balance of an ETH address.
  */
 export default function Balance({ address }: TBalanceProps) {
-  const [isEthBalance, setIsEthBalance] = useState(true);
-  const [balance, setBalance] = useState<number | null>(null);
-
-  const price = useAppStore(state => state.ethPriceSlice.ethPrice);
-
-  const {
-    data: fetchedBalanceData,
-    isError,
-    isLoading,
-  } = useBalance({
-    addressOrName: address,
-    watch: true,
-  });
-
-  const onToggleBalance = () => {
-    setIsEthBalance(!isEthBalance);
-  };
-
-  useEffect(() => {
-    if (fetchedBalanceData?.formatted) {
-      setBalance(Number(fetchedBalanceData.formatted));
-    }
-  }, [fetchedBalanceData]);
+  const { balance, price, isError, isLoading, onToggleBalance, isEthBalance } = useWalletBalance(address);
 
   if (!address || isLoading || balance === null) {
     return (

--- a/packages/nextjs/components/scaffold-eth/Balance.tsx
+++ b/packages/nextjs/components/scaffold-eth/Balance.tsx
@@ -1,4 +1,4 @@
-import { useWalletBalance } from "~~/hooks/scaffold-eth/useWalletBalance";
+import { useAccountBalance } from "~~/hooks/scaffold-eth/useAccountBalance";
 
 type TBalanceProps = {
   address: string;
@@ -8,7 +8,7 @@ type TBalanceProps = {
  * Display (ETH & USD) balance of an ETH address.
  */
 export default function Balance({ address }: TBalanceProps) {
-  const { balance, price, isError, isLoading, onToggleBalance, isEthBalance } = useWalletBalance(address);
+  const { balance, price, isError, isLoading, onToggleBalance, isEthBalance } = useAccountBalance(address);
 
   if (!address || isLoading || balance === null) {
     return (

--- a/packages/nextjs/components/scaffold-eth/Faucet.tsx
+++ b/packages/nextjs/components/scaffold-eth/Faucet.tsx
@@ -42,7 +42,11 @@ export default function Faucet() {
 
   return (
     <div
-      className={!balance ? "tooltip tooltip-left tooltip-secondary font-bold" : ""}
+      className={
+        balance
+          ? ""
+          : "tooltip tooltip-bottom tooltip-secondary tooltip-open font-bold before:left-auto after:border-[6px] before:transform-none before:content-[attr(data-tip)] before:right-0 before:top-[42px]"
+      }
       data-tip="Grab funds from faucet"
     >
       <button

--- a/packages/nextjs/components/scaffold-eth/Faucet.tsx
+++ b/packages/nextjs/components/scaffold-eth/Faucet.tsx
@@ -44,7 +44,7 @@ export default function Faucet() {
       className={
         balance
           ? ""
-          : "tooltip tooltip-bottom tooltip-secondary tooltip-open font-bold before:left-auto after:border-[6px] before:transform-none before:content-[attr(data-tip)] before:right-0 before:top-[42px]"
+          : "tooltip tooltip-bottom tooltip-secondary tooltip-open font-bold before:left-auto before:transform-none before:content-[attr(data-tip)] before:right-0"
       }
       data-tip="Grab funds from faucet"
     >

--- a/packages/nextjs/components/scaffold-eth/Faucet.tsx
+++ b/packages/nextjs/components/scaffold-eth/Faucet.tsx
@@ -4,6 +4,7 @@ import { chain, useAccount, useNetwork } from "wagmi";
 import { useTransactor } from "~~/hooks/scaffold-eth";
 import { getLocalProvider } from "~~/utils/scaffold-eth";
 import { BanknotesIcon } from "@heroicons/react/24/outline";
+import { useWalletBalance } from "~~/hooks/scaffold-eth/useWalletBalance";
 
 // Number of ETH faucet sends to an address
 const NUM_OF_ETH = "1";
@@ -18,6 +19,8 @@ export default function Faucet() {
   const provider = getLocalProvider(chain.localhost);
   const signer = provider?.getSigner();
   const faucetTxn = useTransactor(signer);
+
+  const { balance } = useWalletBalance(address);
 
   const sendETH = async () => {
     try {
@@ -38,12 +41,17 @@ export default function Faucet() {
   }
 
   return (
-    <button
-      className={`btn btn-secondary btn-sm px-2 rounded-full ${loading && "loading"}`}
-      onClick={sendETH}
-      disabled={loading}
+    <div
+      className={!balance ? "tooltip tooltip-left tooltip-secondary font-bold" : ""}
+      data-tip="Grab funds from faucet"
     >
-      <BanknotesIcon className="h-4 w-4" />
-    </button>
+      <button
+        className={`btn btn-secondary btn-sm px-2 rounded-full ${loading ? "loading" : ""}`}
+        onClick={sendETH}
+        disabled={loading}
+      >
+        <BanknotesIcon className="h-4 w-4" />
+      </button>
+    </div>
   );
 }

--- a/packages/nextjs/components/scaffold-eth/Faucet.tsx
+++ b/packages/nextjs/components/scaffold-eth/Faucet.tsx
@@ -4,7 +4,7 @@ import { chain, useAccount, useNetwork } from "wagmi";
 import { useTransactor } from "~~/hooks/scaffold-eth";
 import { getLocalProvider } from "~~/utils/scaffold-eth";
 import { BanknotesIcon } from "@heroicons/react/24/outline";
-import { useWalletBalance } from "~~/hooks/scaffold-eth/useWalletBalance";
+import { useAccountBalance } from "~~/hooks/scaffold-eth/useAccountBalance";
 
 // Number of ETH faucet sends to an address
 const NUM_OF_ETH = "1";
@@ -14,13 +14,12 @@ const NUM_OF_ETH = "1";
  */
 export default function Faucet() {
   const { address } = useAccount();
+  const { balance } = useAccountBalance(address);
   const { chain: ConnectedChain } = useNetwork();
   const [loading, setLoading] = useState(false);
   const provider = getLocalProvider(chain.localhost);
   const signer = provider?.getSigner();
   const faucetTxn = useTransactor(signer);
-
-  const { balance } = useWalletBalance(address);
 
   const sendETH = async () => {
     try {

--- a/packages/nextjs/hooks/scaffold-eth/useAccountBalance.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useAccountBalance.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 import { useBalance } from "wagmi";
 import { useAppStore } from "~~/services/store/store";
 
-export function useWalletBalance(address?: string) {
+export function useAccountBalance(address?: string) {
   const [isEthBalance, setIsEthBalance] = useState(true);
   const [balance, setBalance] = useState<number | null>(null);
   const price = useAppStore(state => state.ethPriceSlice.ethPrice);

--- a/packages/nextjs/hooks/scaffold-eth/useWalletBalance.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useWalletBalance.ts
@@ -1,0 +1,30 @@
+import { useCallback, useEffect, useState } from "react";
+import { useBalance } from "wagmi";
+import { useAppStore } from "~~/services/store/store";
+
+export function useWalletBalance(address?: string) {
+  const [isEthBalance, setIsEthBalance] = useState(true);
+  const [balance, setBalance] = useState<number | null>(null);
+  const price = useAppStore(state => state.ethPriceSlice.ethPrice);
+
+  const {
+    data: fetchedBalanceData,
+    isError,
+    isLoading,
+  } = useBalance({
+    addressOrName: address,
+    watch: true,
+  });
+
+  const onToggleBalance = useCallback(() => {
+    setIsEthBalance(!isEthBalance);
+  }, [isEthBalance]);
+
+  useEffect(() => {
+    if (fetchedBalanceData?.formatted) {
+      setBalance(Number(fetchedBalanceData.formatted));
+    }
+  }, [fetchedBalanceData]);
+
+  return { balance, price, isError, isLoading, onToggleBalance, isEthBalance };
+}

--- a/packages/nextjs/tailwind.config.js
+++ b/packages/nextjs/tailwind.config.js
@@ -25,6 +25,10 @@ module.exports = {
           error: "#FF8863",
 
           "--rounded-btn": "9999rem",
+
+          ".tooltip": {
+            "--tooltip-tail": "6px",
+          },
         },
       },
       {
@@ -47,6 +51,10 @@ module.exports = {
           error: "#FF8863",
 
           "--rounded-btn": "9999rem",
+
+          ".tooltip": {
+            "--tooltip-tail": "6px",
+          },
         },
       },
     ],


### PR DESCRIPTION
daisyui doesn't support complex tooltips, like bottom-left, only centered bottom or centered left. So I placed the tooltip to the left (only when the balance is 0)
<img width="305" alt="image" src="https://user-images.githubusercontent.com/25638585/212723223-60f4ee99-a90f-4c39-8493-b249124f4727.png">

bottom variant is bad:
<img width="310" alt="image" src="https://user-images.githubusercontent.com/25638585/212723460-1c64b79e-4503-4fd6-83da-39c366eb6f47.png">


Possible solutions if you want the bottom tooltip:
- move the faucet button to the left
- use something like `react-popper` https://popper.js.org/react-popper/v2/
