### PR TITLE
update dark theme

### DIFF
--- a/packages/nextjs/components/scaffold-eth/Address.tsx
+++ b/packages/nextjs/components/scaffold-eth/Address.tsx
@@ -77,14 +77,9 @@ export default function Address({
         />
       </div>
       {disableAddressLink ? (
-        <span className="ml-1.5 text-lg font-normal text-gray-900 dark:text-gray-400">{displayAddress}</span>
+        <span className="ml-1.5 text-lg font-normal">{displayAddress}</span>
       ) : (
-        <a
-          className="ml-1.5 text-lg font-normal text-gray-900 dark:text-gray-400"
-          target="_blank"
-          href={explorerLink}
-          rel="noopener noreferrer"
-        >
+        <a className="ml-1.5 text-lg font-normal" target="_blank" href={explorerLink} rel="noopener noreferrer">
           {displayAddress}
         </a>
       )}

--- a/packages/nextjs/components/scaffold-eth/Contract/ContractUI.tsx
+++ b/packages/nextjs/components/scaffold-eth/Contract/ContractUI.tsx
@@ -8,8 +8,8 @@ import {
   getContractWriteMethods,
   getDeployedContract,
 } from "./utilsContract";
-import { getNetworkDetailsByChainId } from "~~/utils/scaffold-eth";
 import { Balance, Address } from "~~/components/scaffold-eth";
+import { useNetworkColor } from "~~/utils/scaffold-eth/useNetworkColor";
 
 type TContractUIProps = {
   contractName: string;
@@ -28,7 +28,7 @@ const ContractUI = ({ contractName }: TContractUIProps) => {
   let contractAddress = "";
   let contractABI = [];
   const deployedContractData = getDeployedContract(chain?.id.toString(), contractName);
-
+  const networkColor = useNetworkColor(chain?.id);
   if (deployedContractData) {
     ({ address: contractAddress, abi: contractABI } = deployedContractData);
   }
@@ -107,7 +107,7 @@ const ContractUI = ({ contractName }: TContractUIProps) => {
       <div className="row-span-1 self-start flex flex-col">
         <div className="bg-base-100 border-base-300 border shadow-md shadow-secondary rounded-3xl px-8 mb-6 space-y-1 py-4">
           {chain && (
-            <p className="font-medium my-0" style={{ color: getNetworkDetailsByChainId(chain.id)?.color }}>
+            <p className="font-medium my-0" style={{ color: networkColor }}>
               {chain.name}
             </p>
           )}

--- a/packages/nextjs/pages/debug.tsx
+++ b/packages/nextjs/pages/debug.tsx
@@ -7,8 +7,8 @@ const Debug: NextPage = () => {
       <div className="grid grid-cols-1 lg:grid-cols-6 py-12 px-10 lg:gap-12 w-full 2xl:max-w-7xl my-0">
         <div>
           <h1 className="text-4xl my-0">Debug Contract</h1>
-          <p className="text-gray-500 font-medium">
-            This is a placeholder text for the introduction to Debug Contracts page.In this page you can...
+          <p className="font-medium">
+            This is a placeholder text for the introduction to Debug Contracts page. In this page you can...
           </p>
         </div>
         <ContractUI contractName="YourContract" />

--- a/packages/nextjs/tailwind.config.js
+++ b/packages/nextjs/tailwind.config.js
@@ -54,7 +54,7 @@ module.exports = {
 
           ".tooltip": {
             "--tooltip-tail": "6px",
-            "--tooltip-color": "#212638",
+            "--tooltip-color": "hsl(var(--p))",
           },
         },
       },

--- a/packages/nextjs/tailwind.config.js
+++ b/packages/nextjs/tailwind.config.js
@@ -54,6 +54,7 @@ module.exports = {
 
           ".tooltip": {
             "--tooltip-tail": "6px",
+            "--tooltip-color": "#212638",
           },
         },
       },

--- a/packages/nextjs/utils/scaffold-eth/networks.ts
+++ b/packages/nextjs/utils/scaffold-eth/networks.ts
@@ -2,14 +2,15 @@ import { Network } from "@ethersproject/networks";
 
 type TChainAttributes = {
   name: string;
-  color: string;
+  // color | [lightThemeColor, darkThemeColor]
+  color: string | [string, string];
   chainId: number;
 };
 
 export const NETWORKS: Record<string, TChainAttributes> = {
   localhost: {
     name: "localhost",
-    color: "#666",
+    color: ["#666666", "#bbbbbb"],
     chainId: 31337,
   },
   mainnet: {
@@ -74,17 +75,17 @@ export const NETWORKS: Record<string, TChainAttributes> = {
   },
   localAvalanche: {
     name: "localAvalanche",
-    color: "#666666",
+    color: ["#666666", "#bbbbbb"],
     chainId: 43112,
   },
   fujiAvalanche: {
     name: "fujiAvalanche",
-    color: "#666666",
+    color: ["#666666", "#bbbbbb"],
     chainId: 43113,
   },
   mainnetAvalanche: {
     name: "mainnetAvalanche",
-    color: "#666666",
+    color: ["#666666", "#bbbbbb"],
     chainId: 43114,
   },
   testnetHarmony: {

--- a/packages/nextjs/utils/scaffold-eth/useNetworkColor.ts
+++ b/packages/nextjs/utils/scaffold-eth/useNetworkColor.ts
@@ -1,0 +1,14 @@
+import { getNetworkDetailsByChainId } from "./networks";
+import { useDarkMode } from "usehooks-ts";
+
+export function useNetworkColor(chainId?: number) {
+  const { isDarkMode } = useDarkMode();
+  const networkDetails = chainId ? getNetworkDetailsByChainId(chainId) : undefined;
+  if (!networkDetails) return "#666666";
+
+  return Array.isArray(networkDetails.color)
+    ? isDarkMode
+      ? networkDetails.color[1]
+      : networkDetails.color[0]
+    : networkDetails.color;
+}


### PR DESCRIPTION
changed the description text color to default, because we don't have a gray color variable for themes. For example, we can use `neutral` color, but not sure. Also, I don't like the way to calculate the color for networks, but for now it at least looks better.

before:
<img width="1328" alt="Screenshot 2023-01-18 at 16 43 18" src="https://user-images.githubusercontent.com/25638585/213197700-50713947-5299-46e3-ad18-722f97ba8939.png">
after:
<img width="1374" alt="image" src="https://user-images.githubusercontent.com/25638585/213197911-20f660ad-1ac7-4d8a-98a0-a4fca06c71eb.png">

