### PR TITLE
Check TS typings on lint-staged and GH actions

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -33,5 +33,8 @@ jobs:
       - name: Run nextjs lint
         run: yarn next:lint --max-warnings=0
 
+      - name: Check typings on nextjs
+        run: yarn next:check-types
+
       - name: Run hardhat lint
         run: yarn hardhat:lint --max-warnings=0

--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -5,12 +5,17 @@ const buildNextEslintCommand = (filenames) =>
     .map((f) => path.relative(path.join("packages", "nextjs"), f))
     .join(" --file ")}`;
 
+const checkTypesNextCommand = () => "yarn next:check-types";
+
 const buildHardhatEslintCommand = (filenames) =>
   `yarn hardhat:lint-staged --fix ${filenames
     .map((f) => path.relative(path.join("packages", "hardhat"), f))
     .join(" ")}`;
 
 module.exports = {
-  "packages/nextjs/**/*.{ts,tsx}": [buildNextEslintCommand],
+  "packages/nextjs/**/*.{ts,tsx}": [
+    buildNextEslintCommand,
+    checkTypesNextCommand,
+  ],
   "packages/hardhat/**/*.{ts,tsx}": [buildHardhatEslintCommand],
 };

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "start": "yarn workspace @se-2/nextjs dev",
     "next:lint": "yarn workspace @se-2/nextjs lint",
     "next:format": "yarn workspace @se-2/nextjs format",
+    "next:check-types": "yarn workspace @se-2/nextjs check-types",
     "postinstall": "husky install",
     "precommit": "lint-staged"
   },

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -8,7 +8,8 @@
     "build": "next build",
     "serve": "next start",
     "lint": "next lint",
-    "format": "prettier --write . '!(node_module|.next|contracts)/**/*'"
+    "format": "prettier --write . '!(node_module|.next|contracts)/**/*'",
+    "check-types": "tsc --noEmit --incremental"
   },
   "dependencies": {
     "@ethersproject/networks": "^5.7.1",


### PR DESCRIPTION
Right now the only way I see type errors is with my IDE.

I added a `yarn next:check-types` to be able to check those.

- Added it to lint-staged: I didn't find a way to check only specific files with TSC (as we do with the linting).
- Added it to the GH Action also.
