### PR TITLE
Handle error when hardhat_contracts.json doesnt exist

### DIFF
--- a/packages/nextjs/components/scaffold-eth/Contract/utilsContract.tsx
+++ b/packages/nextjs/components/scaffold-eth/Contract/utilsContract.tsx
@@ -1,6 +1,4 @@
 import { FunctionFragment } from "ethers/lib/utils";
-// ToDo. Handle when this doesn't exist?
-import ContractData from "~~/generated/hardhat_contracts.json";
 import { Contract, utils } from "ethers";
 import DisplayVariable from "~~/components/scaffold-eth/Contract/DisplayVariables";
 import { ReadOnlyFunctionForm } from "./ReadOnlyFunctionForm";
@@ -22,6 +20,13 @@ const getDeployedContract = (
   contractName: string | undefined | null,
 ): GeneratedContractType | undefined => {
   if (!chainId || !contractName) {
+    return;
+  }
+
+  let ContractData;
+  try {
+    ContractData = require("~~/generated/hardhat_contracts.json");
+  } catch (e) {
     return;
   }
 


### PR DESCRIPTION
In `utilsContract.tsx` we had:

```js
// ToDo. Handle when this doesn't exist?
import ContractData from "~~/generated/hardhat_contracts.json";
```

If people follow the command order specified in the README (chain, deploy, start) this error will never happen. But I feel that we should handle this error, in case the `hardhat_contract.json` is not there.

I tried a few approaches, and this one feels like the most simple one. 
It gives a warning in the console, but not in the UI. UI only gives an error if the file exists and you delete (which seems an edge use case :D).

Can you double check @technophile-04 ?
Happy to consider another approach.