### PR TITLE
Fix network names in env's and add reference to supported chains

### DIFF
--- a/packages/nextjs/.env.development
+++ b/packages/nextjs/.env.development
@@ -1,6 +1,6 @@
 # The network where your DApp lives in.
 # mainnet / hardhat / polygon / optimism / arbitrum / goerli
 # Check supported chains - https://wagmi.sh/core/chains#supported-chains
-NEXT_PUBLIC_NETWORK=matic
+NEXT_PUBLIC_NETWORK=hardhat
 NEXT_PUBLIC_ENABLE_TESTNETS=true
 NEXT_PUBLIC_RPC_POLLING_INTERVAL=30000

--- a/packages/nextjs/.env.development
+++ b/packages/nextjs/.env.development
@@ -1,7 +1,6 @@
 # The network where your DApp lives in.
-# homestead (mainnet) / hardhat / matic / optimism / arbitrum / goerli
-# Check available networks
-# ToDo. Unsupported networks. Show UI warning
-NEXT_PUBLIC_NETWORK=hardhat
+# mainnet / hardhat / polygon / optimism / arbitrum / goerli
+# Check supported chains - https://wagmi.sh/core/chains#supported-chains
+NEXT_PUBLIC_NETWORK=matic
 NEXT_PUBLIC_ENABLE_TESTNETS=true
 NEXT_PUBLIC_RPC_POLLING_INTERVAL=30000

--- a/packages/nextjs/.env.production
+++ b/packages/nextjs/.env.production
@@ -1,3 +1,4 @@
+# Check supported chains - https://wagmi.sh/core/chains#supported-chains
 NEXT_PUBLIC_ENABLE_TESTNETS=false
-NEXT_PUBLIC_NETWORK=homestead
+NEXT_PUBLIC_NETWORK=mainnet
 NEXT_PUBLIC_RPC_POLLING_INTERVAL=30000


### PR DESCRIPTION
### Description 
It seems we are another chain name like `homestead` instead of `mainnet` (might be due to wagmi latest update) which causes the below problem : 

https://user-images.githubusercontent.com/80153681/216852150-a30f6a43-d536-4c96-b683-061de16d6e01.mov

Updated the lookup comment chain name in `env` and also added a link to supported chains from wagmi docs