### PR TITLE
Fix ghost input when using Address Input

### DIFF
--- a/packages/nextjs/components/scaffold-eth/AddressInput.tsx
+++ b/packages/nextjs/components/scaffold-eth/AddressInput.tsx
@@ -58,7 +58,7 @@ const AddressInput = ({ value, name, placeholder, onChange }: TAddressInputProps
   }, [ensData, onChange]);
 
   return (
-    <>
+    <div className="rounded-full border-2 border-base-300">
       <div className="form-control grow">
         <div className="flex w-full">
           {resolvedEns && (
@@ -89,7 +89,7 @@ const AddressInput = ({ value, name, placeholder, onChange }: TAddressInputProps
           )}
         </div>
       </div>
-    </>
+    </div>
   );
 };
 

--- a/packages/nextjs/components/scaffold-eth/Contract/InputUI.tsx
+++ b/packages/nextjs/components/scaffold-eth/Contract/InputUI.tsx
@@ -38,7 +38,7 @@ const InputUI = ({ setForm, form, stateObjectKey, paramType }: TInputUIProps) =>
   }
 
   return (
-    <div className="flex items-end border-2 border-base-300 bg-base-200 rounded-full text-accent justify-between">
+    <>
       {paramType.type === "address" ? (
         <AddressInput
           placeholder={paramType.name ? paramType.type + " " + paramType.name : paramType.type}
@@ -51,22 +51,23 @@ const InputUI = ({ setForm, form, stateObjectKey, paramType }: TInputUIProps) =>
           }}
         />
       ) : (
-        <input
-          placeholder={paramType.name ? paramType.type + " " + paramType.name : paramType.type}
-          autoComplete="off"
-          className="input input-ghost focus:outline-none focus:bg-transparent focus:text-gray-400 h-[2.2rem] min-h-[2.2rem] border w-full font-medium placeholder:text-accent/50 text-gray-400"
-          name={stateObjectKey}
-          value={form[stateObjectKey]}
-          onChange={(event): void => {
-            const formUpdate = { ...form };
-            formUpdate[event.target.name] = event.target.value;
-            setForm(formUpdate);
-          }}
-        />
+        <div className="flex items-end border-2 border-base-300 bg-base-200 rounded-full text-accent justify-between">
+          <input
+            placeholder={paramType.name ? paramType.type + " " + paramType.name : paramType.type}
+            autoComplete="off"
+            className="input input-ghost focus:outline-none focus:bg-transparent focus:text-gray-400 h-[2.2rem] min-h-[2.2rem] border w-full font-medium placeholder:text-accent/50 text-gray-400"
+            name={stateObjectKey}
+            value={form[stateObjectKey]}
+            onChange={(event): void => {
+              const formUpdate = { ...form };
+              formUpdate[event.target.name] = event.target.value;
+              setForm(formUpdate);
+            }}
+          />
+          {inputSuffix}
+        </div>
       )}
-
-      {inputSuffix}
-    </div>
+    </>
   );
 };
 


### PR DESCRIPTION
When using <AddressInput/> outside the Debug page, you were getting a "ghost" input (no borders, invisible when empty)

Before:
![image](https://user-images.githubusercontent.com/2486142/218272115-35faa026-7a95-4d5d-9f8d-0088b284842b.png)

After: 
![image](https://user-images.githubusercontent.com/2486142/218272139-008b77fb-c5f1-4748-bd3d-3678f33ca32c.png)
