### PR TITLE
support arrays input for Contract component

### DIFF
--- a/packages/hardhat/contracts/YourContract.sol
+++ b/packages/hardhat/contracts/YourContract.sol
@@ -1,35 +1,78 @@
+//SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0 <0.9.0;
 
-//SPDX-License-Identifier: MIT
-
+// Useful for debugging. Remove when deploying to a live network.
+import "hardhat/console.sol";
+// Use openzeppelin to inherit battle-tested implementations (ERC20, ERC721, etc)
 // import "@openzeppelin/contracts/access/Ownable.sol";
-// https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/access/Ownable.sol
 
+/**
+ * A smart contract that allows changing a state variable of the contract and tracking the changes
+ * It also allows the owner to withdraw the Ether in the contract
+ * @author BuidlGuidl
+ */
 contract YourContract {
-  address public immutable owner;
-  string[2] public purpose = ["Building Unstoppable Apps!!!", "hello world"];
-  uint256[2] public numArray = [1, 2];
-  bool[2] public boolArray = [true, false];
 
-  constructor(address _owner) payable {
-    // what should we do on deploy?
-    owner = _owner;
-  }
+    // State Variables
+    address public immutable owner;
+    string public greeting = "Building Unstoppable Apps!!!";
+    bool public premium = false;
+    uint256 public totalCounter = 0;
+    mapping(address => uint) public userGreetingCounter;
 
-  function setPurpose(string[2] memory newPurpose) public payable {
-    purpose = newPurpose;
-  }
+    // Events: a way to emit log statements from smart contract that can be listened to by external parties
+    event GreetingChange(address greetingSetter, string newGreeting, bool premium, uint256 value);
 
-  function setNumArray(uint[2] memory newNumArray) public payable {
-    numArray = newNumArray;
-  }
+    // Constructor: Called once on contract deployment
+    // Check packages/hardhat/deploy/00_deploy_your_contract.ts
+    constructor(address _owner) {
+        owner = _owner;
+    }
 
-  function setBoolArray(bool[2] memory newBoolArray) public payable {
-    boolArray = newBoolArray;
-  }
+    // Modifier: used to define a set of rules that must be met before or after a function is executed
+    // Check the withdraw() function
+    modifier isOwner() {
+        // msg.sender: predefined variable that represents address of the account that called the current function
+        require(msg.sender == owner, "Not the Owner");
+        _;
+    }
 
-  // to support receiving ETH by default
-  receive() external payable {}
+    /**
+     * Function that allows anyone to change the state variable "greeting" of the contract and increase the counters
+     *
+     * @param _newGreeting (string memory) - new greeting to save on the contract
+     */
+    function setGreeting(string memory _newGreeting) public payable {
+        // Print data to the hardhat chain console. Remove when deploying to a live network.
+        console.log("Setting new greeting '%s' from %s",  _newGreeting, msg.sender);
 
-  fallback() external payable {}
+        // Change state variables
+        greeting = _newGreeting;
+        totalCounter += 1;
+        userGreetingCounter[msg.sender] += 1;
+
+        // msg.value: built-in global variable that represents the amount of ether sent with the transaction
+        if (msg.value > 0) {
+            premium = true;
+        } else {
+            premium = false;
+        }
+
+        // emit: keyword used to trigger an event
+        emit GreetingChange(msg.sender, _newGreeting, msg.value > 0, 0);
+    }
+
+    /**
+     * Function that allows the owner to withdraw all the Ether in the contract
+     * The function can only be called by the owner of the contract as defined by the isOwner modifier
+     */
+    function withdraw() isOwner public {
+        (bool success,) = owner.call{value: address(this).balance}("");
+        require(success, "Failed to send Ether");
+    }
+
+    /**
+     * Function that allows the contract to receive ETH
+     */
+    receive() external payable {}
 }

--- a/packages/hardhat/contracts/YourContract.sol
+++ b/packages/hardhat/contracts/YourContract.sol
@@ -1,78 +1,35 @@
-//SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0 <0.9.0;
 
-// Useful for debugging. Remove when deploying to a live network.
-import "hardhat/console.sol";
-// Use openzeppelin to inherit battle-tested implementations (ERC20, ERC721, etc)
+//SPDX-License-Identifier: MIT
+
 // import "@openzeppelin/contracts/access/Ownable.sol";
+// https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/access/Ownable.sol
 
-/**
- * A smart contract that allows changing a state variable of the contract and tracking the changes
- * It also allows the owner to withdraw the Ether in the contract
- * @author BuidlGuidl
- */
 contract YourContract {
+  address public immutable owner;
+  string[2] public purpose = ["Building Unstoppable Apps!!!", "hello world"];
+  uint256[2] public numArray = [1, 2];
+  bool[2] public boolArray = [true, false];
 
-    // State Variables
-    address public immutable owner;
-    string public greeting = "Building Unstoppable Apps!!!";
-    bool public premium = false;
-    uint256 public totalCounter = 0;
-    mapping(address => uint) public userGreetingCounter;
+  constructor(address _owner) payable {
+    // what should we do on deploy?
+    owner = _owner;
+  }
 
-    // Events: a way to emit log statements from smart contract that can be listened to by external parties
-    event GreetingChange(address greetingSetter, string newGreeting, bool premium, uint256 value);
+  function setPurpose(string[2] memory newPurpose) public payable {
+    purpose = newPurpose;
+  }
 
-    // Constructor: Called once on contract deployment
-    // Check packages/hardhat/deploy/00_deploy_your_contract.ts
-    constructor(address _owner) {
-        owner = _owner;
-    }
+  function setNumArray(uint[2] memory newNumArray) public payable {
+    numArray = newNumArray;
+  }
 
-    // Modifier: used to define a set of rules that must be met before or after a function is executed
-    // Check the withdraw() function
-    modifier isOwner() {
-        // msg.sender: predefined variable that represents address of the account that called the current function
-        require(msg.sender == owner, "Not the Owner");
-        _;
-    }
+  function setBoolArray(bool[2] memory newBoolArray) public payable {
+    boolArray = newBoolArray;
+  }
 
-    /**
-     * Function that allows anyone to change the state variable "greeting" of the contract and increase the counters
-     *
-     * @param _newGreeting (string memory) - new greeting to save on the contract
-     */
-    function setGreeting(string memory _newGreeting) public payable {
-        // Print data to the hardhat chain console. Remove when deploying to a live network.
-        console.log("Setting new greeting '%s' from %s",  _newGreeting, msg.sender);
+  // to support receiving ETH by default
+  receive() external payable {}
 
-        // Change state variables
-        greeting = _newGreeting;
-        totalCounter += 1;
-        userGreetingCounter[msg.sender] += 1;
-
-        // msg.value: built-in global variable that represents the amount of ether sent with the transaction
-        if (msg.value > 0) {
-            premium = true;
-        } else {
-            premium = false;
-        }
-
-        // emit: keyword used to trigger an event
-        emit GreetingChange(msg.sender, _newGreeting, msg.value > 0, 0);
-    }
-
-    /**
-     * Function that allows the owner to withdraw all the Ether in the contract
-     * The function can only be called by the owner of the contract as defined by the isOwner modifier
-     */
-    function withdraw() isOwner public {
-        (bool success,) = owner.call{value: address(this).balance}("");
-        require(success, "Failed to send Ether");
-    }
-
-    /**
-     * Function that allows the contract to receive ETH
-     */
-    receive() external payable {}
+  fallback() external payable {}
 }

--- a/packages/nextjs/components/scaffold-eth/Contract/InputUI.tsx
+++ b/packages/nextjs/components/scaffold-eth/Contract/InputUI.tsx
@@ -1,19 +1,15 @@
+import { utils } from "ethers";
 import { FunctionFragment } from "ethers/lib/utils";
 import React, { Dispatch, ReactElement, SetStateAction } from "react";
 import { AddressInput } from "~~/components/scaffold-eth";
 
 import { StringToBytesConverter, StringToBytes32Converter, UintToEtherConverter } from "./utilsDisplay";
 
-type ParamType = {
-  name: string | null;
-  type: string;
-};
-
 type TInputUIProps = {
   setForm: Dispatch<SetStateAction<Record<string, any>>>;
   form: Record<string, any>;
   stateObjectKey: string;
-  paramType: ParamType;
+  paramType: utils.ParamType;
   functionFragment: FunctionFragment;
 };
 
@@ -60,7 +56,8 @@ const InputUI = ({ setForm, form, stateObjectKey, paramType }: TInputUIProps) =>
             value={form[stateObjectKey]}
             onChange={(event): void => {
               const formUpdate = { ...form };
-              formUpdate[event.target.name] = event.target.value;
+              const contractFunctionArgument: string | number = event.target.value;
+              formUpdate[event.target.name] = contractFunctionArgument;
               setForm(formUpdate);
             }}
           />

--- a/packages/nextjs/components/scaffold-eth/Contract/ReadOnlyFunctionForm.tsx
+++ b/packages/nextjs/components/scaffold-eth/Contract/ReadOnlyFunctionForm.tsx
@@ -64,6 +64,11 @@ export const ReadOnlyFunctionForm = ({ functionFragment, contractAddress }: TRea
             <span className="block bg-secondary rounded-3xl text-sm px-4 py-1.5">
               <strong>Result</strong>: {displayTxResult(result)}
             </span>
+          ) : result === false ? (
+            // checking if the value returned is literal `false` by contract function
+            <span className="block bg-secondary rounded-3xl text-sm px-4 py-1.5">
+              <strong>Result</strong>: false
+            </span>
           ) : null}
         </div>
         <button

--- a/packages/nextjs/components/scaffold-eth/Contract/ReadOnlyFunctionForm.tsx
+++ b/packages/nextjs/components/scaffold-eth/Contract/ReadOnlyFunctionForm.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 import { useContractRead } from "wagmi";
 import { displayTxResult } from "./utilsDisplay";
 import InputUI from "./InputUI";
-import { getFunctionInputKey } from "./utilsContract";
+import { getFunctionInputKey, getParsedContractFunctionArgs } from "./utilsContract";
 import { getTargetNetwork, notification } from "~~/utils/scaffold-eth";
 
 const getInitialFormState = (functionFragment: FunctionFragment) => {
@@ -22,7 +22,6 @@ type TReadOnlyFunctionFormProps = {
 
 export const ReadOnlyFunctionForm = ({ functionFragment, contractAddress }: TReadOnlyFunctionFormProps) => {
   const [form, setForm] = useState<Record<string, any>>(() => getInitialFormState(functionFragment));
-  const keys = Object.keys(form);
   const configuredChain = getTargetNetwork();
   const {
     data: result,
@@ -33,7 +32,7 @@ export const ReadOnlyFunctionForm = ({ functionFragment, contractAddress }: TRea
     address: contractAddress,
     abi: [functionFragment],
     functionName: functionFragment.name,
-    args: keys.map(key => form[key]),
+    args: getParsedContractFunctionArgs(form),
     enabled: false,
     onError: error => {
       notification.error(error.message);

--- a/packages/nextjs/components/scaffold-eth/Contract/ReadOnlyFunctionForm.tsx
+++ b/packages/nextjs/components/scaffold-eth/Contract/ReadOnlyFunctionForm.tsx
@@ -59,14 +59,9 @@ export const ReadOnlyFunctionForm = ({ functionFragment, contractAddress }: TRea
       {inputs}
       <div className="flex justify-between gap-2">
         <div className="flex-grow">
-          {result ? (
+          {displayTxResult(result) ? (
             <span className="block bg-secondary rounded-3xl text-sm px-4 py-1.5">
               <strong>Result</strong>: {displayTxResult(result)}
-            </span>
-          ) : result === false ? (
-            // checking if the value returned is literal `false` by contract function
-            <span className="block bg-secondary rounded-3xl text-sm px-4 py-1.5">
-              <strong>Result</strong>: false
             </span>
           ) : null}
         </div>

--- a/packages/nextjs/components/scaffold-eth/Contract/WriteOnlyFunctionForm.tsx
+++ b/packages/nextjs/components/scaffold-eth/Contract/WriteOnlyFunctionForm.tsx
@@ -3,38 +3,10 @@ import { Dispatch, SetStateAction, useState } from "react";
 import { useContractWrite, useNetwork, useWaitForTransaction } from "wagmi";
 import InputUI from "./InputUI";
 import TxReceipt from "./TxReceipt";
-import { getFunctionInputKey, getParsedEthersError } from "./utilsContract";
+import { getFunctionInputKey, getParsedContractFunctionArgs, getParsedEthersError } from "./utilsContract";
 import { TxValueInput } from "./utilsComponents";
 import { useTransactor } from "~~/hooks/scaffold-eth";
 import { notification, parseTxnValue, getTargetNetwork } from "~~/utils/scaffold-eth";
-
-const getParsedContractFunctionArgs = (form: Record<string, any>) => {
-  const keys = Object.keys(form);
-  const parsedArguments = keys.map(key => {
-    try {
-      const keySplitArray = key.split("_");
-      const baseTypeOfArg = keySplitArray[keySplitArray.length - 1];
-      console.log("⚡️ ~ file: WriteOnlyFunctionForm.tsx:17 ~ parsedArguments ~ baseTypeOfArg", baseTypeOfArg);
-      let valueOfArg = form[key];
-
-      if (["array", "tuple"].includes(baseTypeOfArg)) {
-        valueOfArg = JSON.parse(valueOfArg);
-      } else if (baseTypeOfArg === "bool") {
-        if (["true", "1", "0x1", "0x01", "0x0001"].includes(valueOfArg)) {
-          valueOfArg = 1;
-        } else {
-          valueOfArg = 0;
-        }
-      }
-
-      console.log("⚡️ ~ file: WriteOnlyFunctionForm.tsx:18 ~ parsedArguments ~ valueOfArg", valueOfArg);
-      return valueOfArg;
-    } catch (error: any) {
-      // ignore error, it will be handled when sending transaction by useContractWrite
-    }
-  });
-  return parsedArguments;
-};
 
 // TODO set sensible initial state values to avoid error on first render, also put it in utilsContract
 const getInitialFormState = (functionFragment: FunctionFragment) => {

--- a/packages/nextjs/components/scaffold-eth/Contract/utilsContract.tsx
+++ b/packages/nextjs/components/scaffold-eth/Contract/utilsContract.tsx
@@ -158,7 +158,7 @@ const getParsedEthersError = (e: any): string => {
 };
 
 /**
- * @dev utility function to parse form input also supports array
+ * @dev Parse form input with array support
  * @param {Record<string,any>} form - form object containing key value pairs
  * @returns  parsed error string
  */

--- a/packages/nextjs/components/scaffold-eth/Contract/utilsContract.tsx
+++ b/packages/nextjs/components/scaffold-eth/Contract/utilsContract.tsx
@@ -157,7 +157,41 @@ const getParsedEthersError = (e: any): string => {
   return message;
 };
 
+/**
+ * @dev utility function to parse form input also supports array
+ * @param {Record<string,any>} form - form object containing key value pairs
+ * @returns  parsed error string
+ */
+const getParsedContractFunctionArgs = (form: Record<string, any>) => {
+  const keys = Object.keys(form);
+  const parsedArguments = keys.map(key => {
+    try {
+      const keySplitArray = key.split("_");
+      const baseTypeOfArg = keySplitArray[keySplitArray.length - 1];
+      console.log("⚡️ ~ file: WriteOnlyFunctionForm.tsx:17 ~ parsedArguments ~ baseTypeOfArg", baseTypeOfArg);
+      let valueOfArg = form[key];
+
+      if (["array", "tuple"].includes(baseTypeOfArg)) {
+        valueOfArg = JSON.parse(valueOfArg);
+      } else if (baseTypeOfArg === "bool") {
+        if (["true", "1", "0x1", "0x01", "0x0001"].includes(valueOfArg)) {
+          valueOfArg = 1;
+        } else {
+          valueOfArg = 0;
+        }
+      }
+
+      console.log("⚡️ ~ file: WriteOnlyFunctionForm.tsx:18 ~ parsedArguments ~ valueOfArg", valueOfArg);
+      return valueOfArg;
+    } catch (error: any) {
+      // ignore error, it will be handled when sending/reading from a function
+    }
+  });
+  return parsedArguments;
+};
+
 export {
+  getParsedContractFunctionArgs,
   getContractReadOnlyMethodsWithParams,
   getAllContractFunctions,
   getContractVariablesAndNoParamsReadMethods,

--- a/packages/nextjs/components/scaffold-eth/Contract/utilsContract.tsx
+++ b/packages/nextjs/components/scaffold-eth/Contract/utilsContract.tsx
@@ -168,7 +168,6 @@ const getParsedContractFunctionArgs = (form: Record<string, any>) => {
     try {
       const keySplitArray = key.split("_");
       const baseTypeOfArg = keySplitArray[keySplitArray.length - 1];
-      console.log("⚡️ ~ file: WriteOnlyFunctionForm.tsx:17 ~ parsedArguments ~ baseTypeOfArg", baseTypeOfArg);
       let valueOfArg = form[key];
 
       if (["array", "tuple"].includes(baseTypeOfArg)) {
@@ -180,8 +179,6 @@ const getParsedContractFunctionArgs = (form: Record<string, any>) => {
           valueOfArg = 0;
         }
       }
-
-      console.log("⚡️ ~ file: WriteOnlyFunctionForm.tsx:18 ~ parsedArguments ~ valueOfArg", valueOfArg);
       return valueOfArg;
     } catch (error: any) {
       // ignore error, it will be handled when sending/reading from a function

--- a/packages/nextjs/components/scaffold-eth/Contract/utilsContract.tsx
+++ b/packages/nextjs/components/scaffold-eth/Contract/utilsContract.tsx
@@ -120,7 +120,7 @@ const getContractWriteMethods = (
  */
 const getFunctionInputKey = (functionInfo: FunctionFragment, input: utils.ParamType, inputIndex: number): string => {
   const name = input?.name || `input_${inputIndex}_`;
-  return functionInfo.name + "_" + name + "_" + input.type;
+  return functionInfo.name + "_" + name + "_" + input.type + "_" + input.baseType;
 };
 
 /**


### PR DESCRIPTION
### Description 
Inspiration was taken from here https://github.com/scaffold-eth/scaffold-eth/blob/e4afffc7e3d6c2bb575240b4de830703e8925548/packages/react-app/src/components/Contract/FunctionForm.jsx#L192 

### Demo 

https://user-images.githubusercontent.com/80153681/218545117-82ca6887-6ff6-4e62-bf1d-86d66dc8e2e1.mov


### Alternate approaches 
currently, if you look at `getParsedContractFunctionArgs` we are there ignoring the error and leaving on wagmi to handle the error. Instead what we can use is `recklesslySetUnpreparedArgs` and check before sending the transaction. Checkout its usage  here -> https://wagmi.sh/react/hooks/useContractWrite#override-config, since its discouraged by wagmi used the current approach but happy to take either approach 🙌

Also, feel free to suggest a change in name of the newly created util function

cc @carletex  @rin-st 