### PR TITLE
fix: show literal false value returned by contract

### DIFF
--- a/packages/hardhat/contracts/YourContract.sol
+++ b/packages/hardhat/contracts/YourContract.sol
@@ -3,6 +3,7 @@ pragma solidity >=0.8.0 <0.9.0;
 
 // Useful for debugging. Remove when deploying to a live network.
 import "hardhat/console.sol";
+
 // Use openzeppelin to inherit battle-tested implementations (ERC20, ERC721, etc)
 // import "@openzeppelin/contracts/access/Ownable.sol";
 
@@ -12,67 +13,70 @@ import "hardhat/console.sol";
  * @author BuidlGuidl
  */
 contract YourContract {
+  // State Variables
+  address public immutable owner;
+  string public greeting = "Building Unstoppable Apps!!!";
+  bool public premium = false;
+  uint256 public totalCounter = 0;
+  mapping(address => uint) public userGreetingCounter;
 
-    // State Variables
-    address public immutable owner;
-    string public greeting = "Building Unstoppable Apps!!!";
-    bool public premium = false;
-    uint256 public totalCounter = 0;
-    mapping(address => uint) public userGreetingCounter;
+  // Events: a way to emit log statements from smart contract that can be listened to by external parties
+  event GreetingChange(address greetingSetter, string newGreeting, bool premium, uint256 value);
 
-    // Events: a way to emit log statements from smart contract that can be listened to by external parties
-    event GreetingChange(address greetingSetter, string newGreeting, bool premium, uint256 value);
+  // Constructor: Called once on contract deployment
+  // Check packages/hardhat/deploy/00_deploy_your_contract.ts
+  constructor(address _owner) {
+    owner = _owner;
+  }
 
-    // Constructor: Called once on contract deployment
-    // Check packages/hardhat/deploy/00_deploy_your_contract.ts
-    constructor(address _owner) {
-        owner = _owner;
+  // Modifier: used to define a set of rules that must be met before or after a function is executed
+  // Check the withdraw() function
+  modifier isOwner() {
+    // msg.sender: predefined variable that represents address of the account that called the current function
+    require(msg.sender == owner, "Not the Owner");
+    _;
+  }
+
+  function showBool(bool x) public pure returns (bool) {
+    return x;
+  }
+
+  /**
+   * Function that allows anyone to change the state variable "greeting" of the contract and increase the counters
+   *
+   * @param _newGreeting (string memory) - new greeting to save on the contract
+   */
+  function setGreeting(string memory _newGreeting) public payable {
+    // Print data to the hardhat chain console. Remove when deploying to a live network.
+    console.log("Setting new greeting '%s' from %s", _newGreeting, msg.sender);
+
+    // Change state variables
+    greeting = _newGreeting;
+    totalCounter += 1;
+    userGreetingCounter[msg.sender] += 1;
+
+    // msg.value: built-in global variable that represents the amount of ether sent with the transaction
+    if (msg.value > 0) {
+      premium = true;
+    } else {
+      premium = false;
     }
 
-    // Modifier: used to define a set of rules that must be met before or after a function is executed
-    // Check the withdraw() function
-    modifier isOwner() {
-        // msg.sender: predefined variable that represents address of the account that called the current function
-        require(msg.sender == owner, "Not the Owner");
-        _;
-    }
+    // emit: keyword used to trigger an event
+    emit GreetingChange(msg.sender, _newGreeting, msg.value > 0, 0);
+  }
 
-    /**
-     * Function that allows anyone to change the state variable "greeting" of the contract and increase the counters
-     *
-     * @param _newGreeting (string memory) - new greeting to save on the contract
-     */
-    function setGreeting(string memory _newGreeting) public payable {
-        // Print data to the hardhat chain console. Remove when deploying to a live network.
-        console.log("Setting new greeting '%s' from %s",  _newGreeting, msg.sender);
+  /**
+   * Function that allows the owner to withdraw all the Ether in the contract
+   * The function can only be called by the owner of the contract as defined by the isOwner modifier
+   */
+  function withdraw() public isOwner {
+    (bool success, ) = owner.call{value: address(this).balance}("");
+    require(success, "Failed to send Ether");
+  }
 
-        // Change state variables
-        greeting = _newGreeting;
-        totalCounter += 1;
-        userGreetingCounter[msg.sender] += 1;
-
-        // msg.value: built-in global variable that represents the amount of ether sent with the transaction
-        if (msg.value > 0) {
-            premium = true;
-        } else {
-            premium = false;
-        }
-
-        // emit: keyword used to trigger an event
-        emit GreetingChange(msg.sender, _newGreeting, msg.value > 0, 0);
-    }
-
-    /**
-     * Function that allows the owner to withdraw all the Ether in the contract
-     * The function can only be called by the owner of the contract as defined by the isOwner modifier
-     */
-    function withdraw() isOwner public {
-        (bool success,) = owner.call{value: address(this).balance}("");
-        require(success, "Failed to send Ether");
-    }
-
-    /**
-     * Function that allows the contract to receive ETH
-     */
-    receive() external payable {}
+  /**
+   * Function that allows the contract to receive ETH
+   */
+  receive() external payable {}
 }

--- a/packages/hardhat/contracts/YourContract.sol
+++ b/packages/hardhat/contracts/YourContract.sol
@@ -3,7 +3,6 @@ pragma solidity >=0.8.0 <0.9.0;
 
 // Useful for debugging. Remove when deploying to a live network.
 import "hardhat/console.sol";
-
 // Use openzeppelin to inherit battle-tested implementations (ERC20, ERC721, etc)
 // import "@openzeppelin/contracts/access/Ownable.sol";
 
@@ -13,70 +12,67 @@ import "hardhat/console.sol";
  * @author BuidlGuidl
  */
 contract YourContract {
-  // State Variables
-  address public immutable owner;
-  string public greeting = "Building Unstoppable Apps!!!";
-  bool public premium = false;
-  uint256 public totalCounter = 0;
-  mapping(address => uint) public userGreetingCounter;
 
-  // Events: a way to emit log statements from smart contract that can be listened to by external parties
-  event GreetingChange(address greetingSetter, string newGreeting, bool premium, uint256 value);
+    // State Variables
+    address public immutable owner;
+    string public greeting = "Building Unstoppable Apps!!!";
+    bool public premium = false;
+    uint256 public totalCounter = 0;
+    mapping(address => uint) public userGreetingCounter;
 
-  // Constructor: Called once on contract deployment
-  // Check packages/hardhat/deploy/00_deploy_your_contract.ts
-  constructor(address _owner) {
-    owner = _owner;
-  }
+    // Events: a way to emit log statements from smart contract that can be listened to by external parties
+    event GreetingChange(address greetingSetter, string newGreeting, bool premium, uint256 value);
 
-  // Modifier: used to define a set of rules that must be met before or after a function is executed
-  // Check the withdraw() function
-  modifier isOwner() {
-    // msg.sender: predefined variable that represents address of the account that called the current function
-    require(msg.sender == owner, "Not the Owner");
-    _;
-  }
-
-  function showBool(bool x) public pure returns (bool) {
-    return x;
-  }
-
-  /**
-   * Function that allows anyone to change the state variable "greeting" of the contract and increase the counters
-   *
-   * @param _newGreeting (string memory) - new greeting to save on the contract
-   */
-  function setGreeting(string memory _newGreeting) public payable {
-    // Print data to the hardhat chain console. Remove when deploying to a live network.
-    console.log("Setting new greeting '%s' from %s", _newGreeting, msg.sender);
-
-    // Change state variables
-    greeting = _newGreeting;
-    totalCounter += 1;
-    userGreetingCounter[msg.sender] += 1;
-
-    // msg.value: built-in global variable that represents the amount of ether sent with the transaction
-    if (msg.value > 0) {
-      premium = true;
-    } else {
-      premium = false;
+    // Constructor: Called once on contract deployment
+    // Check packages/hardhat/deploy/00_deploy_your_contract.ts
+    constructor(address _owner) {
+        owner = _owner;
     }
 
-    // emit: keyword used to trigger an event
-    emit GreetingChange(msg.sender, _newGreeting, msg.value > 0, 0);
-  }
+    // Modifier: used to define a set of rules that must be met before or after a function is executed
+    // Check the withdraw() function
+    modifier isOwner() {
+        // msg.sender: predefined variable that represents address of the account that called the current function
+        require(msg.sender == owner, "Not the Owner");
+        _;
+    }
 
-  /**
-   * Function that allows the owner to withdraw all the Ether in the contract
-   * The function can only be called by the owner of the contract as defined by the isOwner modifier
-   */
-  function withdraw() public isOwner {
-    (bool success, ) = owner.call{value: address(this).balance}("");
-    require(success, "Failed to send Ether");
-  }
+    /**
+     * Function that allows anyone to change the state variable "greeting" of the contract and increase the counters
+     *
+     * @param _newGreeting (string memory) - new greeting to save on the contract
+     */
+    function setGreeting(string memory _newGreeting) public payable {
+        // Print data to the hardhat chain console. Remove when deploying to a live network.
+        console.log("Setting new greeting '%s' from %s",  _newGreeting, msg.sender);
 
-  /**
-   * Function that allows the contract to receive ETH
-   */
-  receive() external payable {}
+        // Change state variables
+        greeting = _newGreeting;
+        totalCounter += 1;
+        userGreetingCounter[msg.sender] += 1;
+
+        // msg.value: built-in global variable that represents the amount of ether sent with the transaction
+        if (msg.value > 0) {
+            premium = true;
+        } else {
+            premium = false;
+        }
+
+        // emit: keyword used to trigger an event
+        emit GreetingChange(msg.sender, _newGreeting, msg.value > 0, 0);
+    }
+
+    /**
+     * Function that allows the owner to withdraw all the Ether in the contract
+     * The function can only be called by the owner of the contract as defined by the isOwner modifier
+     */
+    function withdraw() isOwner public {
+        (bool success,) = owner.call{value: address(this).balance}("");
+        require(success, "Failed to send Ether");
+    }
+
+    /**
+     * Function that allows the contract to receive ETH
+     */
+    receive() external payable {}
 }

--- a/packages/nextjs/components/scaffold-eth/Contract/ReadOnlyFunctionForm.tsx
+++ b/packages/nextjs/components/scaffold-eth/Contract/ReadOnlyFunctionForm.tsx
@@ -59,6 +59,7 @@ export const ReadOnlyFunctionForm = ({ functionFragment, contractAddress }: TRea
       {inputs}
       <div className="flex justify-between gap-2">
         <div className="flex-grow">
+          {/* using looseEqual to check only for null and undefined value */}
           {result != null && (
             <span className="block bg-secondary rounded-3xl text-sm px-4 py-1.5">
               <strong>Result</strong>: {displayTxResult(result)}

--- a/packages/nextjs/components/scaffold-eth/Contract/ReadOnlyFunctionForm.tsx
+++ b/packages/nextjs/components/scaffold-eth/Contract/ReadOnlyFunctionForm.tsx
@@ -59,11 +59,11 @@ export const ReadOnlyFunctionForm = ({ functionFragment, contractAddress }: TRea
       {inputs}
       <div className="flex justify-between gap-2">
         <div className="flex-grow">
-          {result != null ? (
+          {result != null && (
             <span className="block bg-secondary rounded-3xl text-sm px-4 py-1.5">
               <strong>Result</strong>: {displayTxResult(result)}
             </span>
-          ) : null}
+          )}
         </div>
         <button
           className={`btn btn-secondary btn-sm ${isFetching ? "loading" : ""}`}

--- a/packages/nextjs/components/scaffold-eth/Contract/ReadOnlyFunctionForm.tsx
+++ b/packages/nextjs/components/scaffold-eth/Contract/ReadOnlyFunctionForm.tsx
@@ -59,8 +59,7 @@ export const ReadOnlyFunctionForm = ({ functionFragment, contractAddress }: TRea
       {inputs}
       <div className="flex justify-between gap-2">
         <div className="flex-grow">
-          {/* using looseEqual to check only for null and undefined value */}
-          {result != null && (
+          {result !== null && result !== undefined && (
             <span className="block bg-secondary rounded-3xl text-sm px-4 py-1.5">
               <strong>Result</strong>: {displayTxResult(result)}
             </span>

--- a/packages/nextjs/components/scaffold-eth/Contract/ReadOnlyFunctionForm.tsx
+++ b/packages/nextjs/components/scaffold-eth/Contract/ReadOnlyFunctionForm.tsx
@@ -59,7 +59,7 @@ export const ReadOnlyFunctionForm = ({ functionFragment, contractAddress }: TRea
       {inputs}
       <div className="flex justify-between gap-2">
         <div className="flex-grow">
-          {result ? (
+          {result != null ? (
             <span className="block bg-secondary rounded-3xl text-sm px-4 py-1.5">
               <strong>Result</strong>: {displayTxResult(result)}
             </span>


### PR DESCRIPTION
### Description
It seems if the contract read function returns `false` then its not show in the UI 

#### Before 

https://user-images.githubusercontent.com/80153681/219032901-2152254f-6e49-413c-9b51-3c0d475f437e.mov

### After 

https://user-images.githubusercontent.com/80153681/219033862-fa27f9d6-edce-42b1-9ab1-0163a94e74c5.mov

### Approach 
used looseEqual to check only for null and undefined, checkout -> https://stackoverflow.com/a/15992131

cc @carletex @rin-st, would be happy to refactor if I missed some cases 🙌