### PR TITLE
fix UI break if local chain not running 

### DIFF
--- a/packages/nextjs/components/scaffold-eth/Faucet.tsx
+++ b/packages/nextjs/components/scaffold-eth/Faucet.tsx
@@ -30,9 +30,14 @@ export default function Faucet() {
 
   useEffect(() => {
     const getFaucetAddress = async () => {
-      if (provider) {
-        const accounts = await provider.listAccounts();
-        setFaucetAddress(accounts[FAUCET_ACCOUNT_INDEX]);
+      try {
+        if (provider) {
+          const accounts = await provider.listAccounts();
+          setFaucetAddress(accounts[FAUCET_ACCOUNT_INDEX]);
+        }
+      } catch (error) {
+        notification.error("Cannot connect to local provider");
+        console.log("⚡️ ~ file: Faucet.tsx:39 ~ getFaucetAddress ~ error", error);
       }
     };
     getFaucetAddress();


### PR DESCRIPTION
### Desc 
I think this was introduced in #154 while listing account. If you forgot to do `yarn start` the UI break with the below error
![Screenshot 2023-02-16 at 12 26 13 AM](https://user-images.githubusercontent.com/80153681/219129683-b5cc5652-80f3-4ee6-b154-f5da78fe32de.jpg)

### Approach : 
Added a very basic error, feel free to suggest a different error message because the current one might seem too specific also maybe we can silent error. 

### More suggestion 
I was also wondering if we should do `notification.error("Signer not found")` here:  https://github.com/scaffold-eth/se-2/blob/f2fde1e04a02defc111d12776288996da232b9b6/packages/nextjs/hooks/scaffold-eth/useTransactor.tsx#L44