### PR TITLE
feat(nav): make top nav sticky for easier access on mobile

### DIFF
--- a/packages/nextjs/components/Header.tsx
+++ b/packages/nextjs/components/Header.tsx
@@ -56,7 +56,7 @@ export default function Header() {
   );
 
   return (
-    <div className="sticky top-0 navbar bg-base-100 min-h-0 flex-shrink-0 justify-between z-20">
+    <div className="sticky top-0 navbar bg-base-100 min-h-0 flex-shrink-0 justify-between z-20 shadow-md shadow-secondary">
       <div className="navbar-start w-auto lg:w-1/2">
         <div className="lg:hidden dropdown" ref={burgerMenuRef}>
           <button

--- a/packages/nextjs/components/Header.tsx
+++ b/packages/nextjs/components/Header.tsx
@@ -56,8 +56,8 @@ export default function Header() {
   );
 
   return (
-    <div className="navbar bg-base-100 min-h-0 flex-shrink-0 justify-between z-10">
-      <div className="navbar-start w-auto lg:w-1/2 ">
+    <div className="sticky top-0 navbar bg-base-100 min-h-0 flex-shrink-0 justify-between z-20">
+      <div className="navbar-start w-auto lg:w-1/2">
         <div className="lg:hidden dropdown" ref={burgerMenuRef}>
           <button
             className={`ml-1 btn btn-ghost ${isDrawerOpen ? "hover:bg-secondary" : "hover:bg-transparent"}`}

--- a/packages/nextjs/pages/_app.tsx
+++ b/packages/nextjs/pages/_app.tsx
@@ -35,7 +35,7 @@ const ScaffoldEthApp = ({ Component, pageProps }: AppProps) => {
       <RainbowKitProvider chains={appChains.chains} avatar={BlockieAvatar}>
         <div className="flex flex-col min-h-screen">
           <Header />
-          <main className="flex flex-col flex-1">
+          <main className="relative flex flex-col flex-1">
             <Component {...pageProps} />
           </main>
           <Footer />


### PR DESCRIPTION
For improved UX (especially on mobile), I think the header should be sticky in order to always have easy access to navigation and address functionalities.