### PR TITLE
fix(spacing): decrease some paddings on mobile

### DIFF
--- a/packages/nextjs/components/scaffold-eth/Contract/ContractUI.tsx
+++ b/packages/nextjs/components/scaffold-eth/Contract/ContractUI.tsx
@@ -59,7 +59,7 @@ const ContractUI = ({ contractName }: TContractUIProps) => {
   }
 
   return (
-    <div className="col-span-5 grid grid-cols-1 lg:grid-cols-3 gap-10 justify-between">
+    <div className="col-span-5 grid grid-cols-1 lg:grid-cols-3 gap-y-10 lg:gap-10 justify-between">
       <div className="col-span-2 flex flex-col gap-6">
         <div className="z-10">
           <div className="bg-base-100 rounded-3xl shadow-md shadow-secondary border border-base-300 collapse collapse-arrow overflow-visible flex flex-col mt-10 ">

--- a/packages/nextjs/pages/debug.tsx
+++ b/packages/nextjs/pages/debug.tsx
@@ -4,7 +4,7 @@ import { ContractUI } from "~~/components/scaffold-eth";
 const Debug: NextPage = () => {
   return (
     <div className="flex justify-center">
-      <div className="grid grid-cols-1 lg:grid-cols-6 py-12 px-10 lg:gap-12 w-full 2xl:max-w-7xl my-0">
+      <div className="grid grid-cols-1 lg:grid-cols-6 py-6 lg:py-12 px-6 lg:px-10 lg:gap-12 w-full 2xl:max-w-7xl my-0">
         <div>
           <h1 className="text-4xl my-0">Debug Contract</h1>
           <p className="font-medium">


### PR DESCRIPTION
A fix to make the chain and contract variables display full width on mobile (to match the read and write components that precede it).
Additionally, small padding improvements for mobile to better use limited screen real estate.