### PR TITLE
Error toast of faucet on deployement networks

### DIFF
--- a/packages/nextjs/components/Footer.tsx
+++ b/packages/nextjs/components/Footer.tsx
@@ -4,12 +4,15 @@ import { useAppStore } from "~~/services/store/store";
 import { HeartIcon } from "@heroicons/react/24/outline";
 import SwitchTheme from "./SwitchTheme";
 import { Faucet } from "~~/components/scaffold-eth";
+import { getTargetNetwork } from "~~/utils/scaffold-eth";
+import { hardhat } from "wagmi/chains";
 
 /**
  * Site footer
  */
 export default function Footer() {
   const ethPrice = useAppStore(state => state.ethPrice);
+  const configuredNetwork = getTargetNetwork();
 
   return (
     <div className="min-h-0 p-5 flex justify-between items-center flex-col sm:flex-row gap-4">
@@ -21,7 +24,7 @@ export default function Footer() {
               <span>{ethPrice}</span>
             </div>
           )}
-          <Faucet />
+          {configuredNetwork.id === hardhat.id && <Faucet />}
         </div>
       </div>
       <div>


### PR DESCRIPTION
### Description 
When you configure `env` network other than `hardhat` we get the following error  on the first render: 

![Screenshot 2023-02-17 at 10 06 45 AM](https://user-images.githubusercontent.com/80153681/219550535-ed9e1b1f-dcd2-4281-9cd0-8504a170f0f8.jpg)

### Reason 
Since `getFaucetAddress` is used in `useEffect` and is called on render irrespective of chain configured in `env` https://github.com/scaffold-eth/se-2/blob/2a61bc87ac80f1e2de9dd6cad0cc10eebf2703e6/packages/nextjs/components/scaffold-eth/Faucet.tsx#L48

### Approach 
Added a guard at `Footer.jsx` level, since this seems the most minimal and clean

### another approach 
Instead of adding guard at `Footer.jsx` level, we can have it before calling the function https://github.com/scaffold-eth/se-2/blob/2a61bc87ac80f1e2de9dd6cad0cc10eebf2703e6/packages/nextjs/components/scaffold-eth/Faucet.tsx#L48