### PR TITLE
fix: balance view

### DIFF
--- a/packages/nextjs/components/scaffold-eth/Balance.tsx
+++ b/packages/nextjs/components/scaffold-eth/Balance.tsx
@@ -2,12 +2,13 @@ import { useAccountBalance } from "~~/hooks/scaffold-eth/useAccountBalance";
 
 type TBalanceProps = {
   address?: string;
+  className?: string;
 };
 
 /**
  * Display (ETH & USD) balance of an ETH address.
  */
-export default function Balance({ address }: TBalanceProps) {
+export default function Balance({ address, className = "" }: TBalanceProps) {
   const { balance, price, isError, isLoading, onToggleBalance, isEthBalance } = useAccountBalance(address);
 
   if (!address || isLoading || balance === null) {
@@ -23,7 +24,7 @@ export default function Balance({ address }: TBalanceProps) {
 
   if (isError) {
     return (
-      <div className={`border-2 border-gray-400 rounded-md p-2 flex flex-col items-center max-w-fit cursor-pointer`}>
+      <div className={`border-2 border-gray-400 rounded-md px-2 flex flex-col items-center max-w-fit cursor-pointer`}>
         <div className="text-warning text-xs">Error</div>
       </div>
     );
@@ -31,18 +32,18 @@ export default function Balance({ address }: TBalanceProps) {
 
   return (
     <button
-      className="btn btn-sm btn-ghost flex flex-col font-normal items-center hover:bg-transparent"
+      className={`btn btn-sm btn-ghost flex flex-col font-normal items-center hover:bg-transparent ${className}`}
       onClick={onToggleBalance}
     >
       <div className="w-full flex items-center justify-center">
         {isEthBalance ? (
           <>
             <span>{balance?.toFixed(4)}</span>
-            <span className="text-xs font-bold m-1">ETH</span>
+            <span className="text-xs font-bold ml-1">ETH</span>
           </>
         ) : (
           <>
-            <span className="text-xs font-bold m-1">$</span>
+            <span className="text-xs font-bold mr-1">$</span>
             <span>{(balance * price).toFixed(2)}</span>
           </>
         )}

--- a/packages/nextjs/components/scaffold-eth/Contract/ContractUI.tsx
+++ b/packages/nextjs/components/scaffold-eth/Contract/ContractUI.tsx
@@ -63,14 +63,17 @@ const ContractUI = ({ contractName }: TContractUIProps) => {
       <div className="col-span-1 flex flex-col">
         <div className="bg-base-100 border-base-300 border shadow-md shadow-secondary rounded-3xl px-8 mb-6 space-y-1 py-4">
           <div className="flex">
-            <div className="flex gap-1">
+            <div className="flex flex-col gap-1">
               <Address address={contractAddress} />
-              <Balance address={contractAddress} />
+              <div className="flex gap-1 items-center">
+                <span className="font-bold text-sm">Balance:</span>
+                <Balance address={contractAddress} className="px-0 h-1.5 min-h-[0.375rem]" />
+              </div>
             </div>
           </div>
           {chain && (
-            <p className="my-0 text-sm" style={{ color: networkColor }}>
-              <span className="font-bold">Network</span> : {chain.name}
+            <p className="my-0 text-sm">
+              <span className="font-bold">Network</span>: <span style={{ color: networkColor }}>{chain.name}</span>
             </p>
           )}
         </div>


### PR DESCRIPTION
Fixes balance view, it's broken for some resolutions, and now it's clear what that value means. Also changed "Network:" text color.

before:
<img width="1025" alt="Screenshot 2023-02-17 at 18 28 46" src="https://user-images.githubusercontent.com/25638585/219682269-4a51fa97-6b8d-4712-81da-6249e5706244.png">

after:
<img width="1021" alt="Screenshot 2023-02-17 at 18 28 25" src="https://user-images.githubusercontent.com/25638585/219682299-02adf1c2-1290-42c3-b153-3eb4556acd5e.png">
