### PR TITLE
Address component: EnsAvatar + cleanup

### DIFF
--- a/packages/nextjs/components/scaffold-eth/Address.tsx
+++ b/packages/nextjs/components/scaffold-eth/Address.tsx
@@ -2,8 +2,9 @@ import React, { useEffect, useState } from "react";
 import Blockies from "react-blockies";
 import { DocumentDuplicateIcon, CheckCircleIcon } from "@heroicons/react/24/outline";
 import { CopyToClipboard } from "react-copy-to-clipboard";
-import { useEnsName } from "wagmi";
+import { useEnsAvatar, useEnsName } from "wagmi";
 import { ethers } from "ethers";
+import { isAddress } from "ethers/lib/utils";
 
 const blockExplorerLink = (address: string, blockExplorer?: string) =>
   `${blockExplorer || "https://etherscan.io/"}address/${address}`;
@@ -12,31 +13,33 @@ type TAddressProps = {
   address?: string;
   blockExplorer?: string;
   disableAddressLink?: boolean;
-  fontSize?: number;
   format?: "short" | "long";
-  minimized?: boolean;
 };
 
 /**
  * Displays an address (or ENS) with a Blockie image and option to copy address.
  */
-export default function Address({
-  address,
-  blockExplorer,
-  disableAddressLink,
-  fontSize,
-  format,
-  minimized,
-}: TAddressProps) {
+export default function Address({ address, blockExplorer, disableAddressLink, format }: TAddressProps) {
   const [ens, setEns] = useState<string | null>();
+  const [ensAvatar, setEnsAvatar] = useState<string | null>();
   const [addressCopied, setAddressCopied] = useState(false);
 
-  const { data: fetchedEns } = useEnsName({ address, chainId: 1 });
+  const { data: fetchedEns } = useEnsName({ address, enabled: isAddress(address ?? ""), chainId: 1 });
+  const { data: fetchedEnsAvatar } = useEnsAvatar({
+    address,
+    enabled: isAddress(address ?? ""),
+    chainId: 1,
+    cacheTime: 30_000,
+  });
 
   // We need to apply this pattern to avoid Hydration errors.
   useEffect(() => {
     setEns(fetchedEns);
   }, [fetchedEns]);
+
+  useEffect(() => {
+    setEnsAvatar(fetchedEnsAvatar);
+  }, [fetchedEnsAvatar]);
 
   // Skeleton UI
   if (!address) {
@@ -63,23 +66,16 @@ export default function Address({
     displayAddress = address;
   }
 
-  if (minimized) {
-    return (
-      <a target="_blank" href={explorerLink} rel="noopener noreferrer">
-        <Blockies className="inline rounded-md" size={8} scale={2} seed={address.toLowerCase()} />
-      </a>
-    );
-  }
-
   return (
     <div className="flex items-center">
       <div className="flex-shrink-0">
-        <Blockies
-          className="mx-auto rounded-md"
-          size={5}
-          seed={address.toLowerCase()}
-          scale={fontSize ? fontSize / 7 : 4}
-        />
+        {ensAvatar ? (
+          // Don't want to use nextJS Image here (and adding remote patterns for the URL)
+          // eslint-disable-next-line
+          <img className="rounded-full" src={ensAvatar} width={24} height={24} alt={`${address} avatar`} />
+        ) : (
+          <Blockies className="mx-auto rounded-full" size={8} seed={address.toLowerCase()} scale={3} />
+        )}
       </div>
       {disableAddressLink ? (
         <span className="ml-1.5 text-lg font-normal">{displayAddress}</span>


### PR DESCRIPTION
- Show EnsAvatar on the Address component (if any).
- Rounded blockie (+ bigger size) to match UI vibe
- Remove extra stuff (font-size / minimized). It was inherited from SE1, we are not using rn... and it had some missing stuff (like adjusting the text fontsize). We'll be standardizing components soon (maybe "classNames" as the Balance component).

**Before**
![1](https://user-images.githubusercontent.com/2486142/219728788-c35a216d-f26f-4318-aede-961b0815366f.png)

**After**
![2](https://user-images.githubusercontent.com/2486142/219728792-65d6271b-9b83-4240-ae4f-8cdba3e00b4d.png)
![3](https://user-images.githubusercontent.com/2486142/219728852-81667292-4c89-4e0a-828d-67bf917686b6.png)
