### PR TITLE
HOTFIX: Mainnet working when selected as target network

### DIFF
--- a/packages/nextjs/components/scaffold-eth/Contract/ContractUI.tsx
+++ b/packages/nextjs/components/scaffold-eth/Contract/ContractUI.tsx
@@ -1,6 +1,6 @@
 import { Contract } from "ethers";
 import { useMemo, useState } from "react";
-import { useContract, useNetwork, useProvider } from "wagmi";
+import { useContract, useProvider } from "wagmi";
 import {
   getAllContractFunctions,
   getContractReadOnlyMethodsWithParams,
@@ -10,6 +10,7 @@ import {
 import { Balance, Address } from "~~/components/scaffold-eth";
 import { useDeployedContractInfo } from "~~/hooks/scaffold-eth";
 import { useNetworkColor } from "~~/utils/scaffold-eth/useNetworkColor";
+import { getTargetNetwork } from "~~/utils/scaffold-eth";
 
 type TContractUIProps = {
   contractName: string;
@@ -21,14 +22,14 @@ type TContractUIProps = {
  * ToDo. Handle loading state
  **/
 const ContractUI = ({ contractName }: TContractUIProps) => {
-  const { chain } = useNetwork();
+  const configuredChain = getTargetNetwork();
   const provider = useProvider();
   const [refreshDisplayVariables, setRefreshDisplayVariables] = useState(false);
 
   let contractAddress = "";
   let contractABI = [];
   const deployedContractData = useDeployedContractInfo(contractName);
-  const networkColor = useNetworkColor(chain?.id);
+  const networkColor = useNetworkColor(configuredChain.id);
   if (deployedContractData) {
     ({ address: contractAddress, abi: contractABI } = deployedContractData);
   }
@@ -71,9 +72,10 @@ const ContractUI = ({ contractName }: TContractUIProps) => {
               </div>
             </div>
           </div>
-          {chain && (
+          {configuredChain && (
             <p className="my-0 text-sm">
-              <span className="font-bold">Network</span>: <span style={{ color: networkColor }}>{chain.name}</span>
+              <span className="font-bold">Network</span>:{" "}
+              <span style={{ color: networkColor }}>{configuredChain.name}</span>
             </p>
           )}
         </div>

--- a/packages/nextjs/utils/scaffold-eth/networks.ts
+++ b/packages/nextjs/utils/scaffold-eth/networks.ts
@@ -1,133 +1,132 @@
 import { Network } from "@ethersproject/networks";
-import { appChains } from "~~/services/web3/wagmiConnectors";
 
 export type TChainAttributes = {
   name: string;
   // color | [lightThemeColor, darkThemeColor]
   color: string | [string, string];
-  chainId: number;
+  id: number;
 };
 
 export const NETWORKS: Record<string, TChainAttributes> = {
-  localhost: {
-    name: "localhost",
+  hardhat: {
+    name: "hardhat",
     color: ["#666666", "#bbbbbb"],
-    chainId: 31337,
+    id: 31337,
   },
   mainnet: {
     name: "mainnet",
     color: "#ff8b9e",
-    chainId: 1,
+    id: 1,
   },
   goerli: {
     name: "goerli",
     color: "#0975F6",
-    chainId: 5,
+    id: 5,
   },
   gnosis: {
     name: "gnosis",
     color: "#48a9a6",
-    chainId: 100,
+    id: 100,
   },
   polygon: {
     name: "polygon",
     color: "#2bbdf7",
-    chainId: 137,
+    id: 137,
   },
   mumbai: {
     name: "mumbai",
     color: "#92D9FA",
-    chainId: 80001,
+    id: 80001,
   },
   localOptimismL1: {
     name: "localOptimismL1",
     color: "#f01a37",
-    chainId: 31337,
+    id: 31337,
   },
   localOptimism: {
     name: "localOptimism",
     color: "#f01a37",
-    chainId: 420,
+    id: 420,
   },
   goerliOptimism: {
     name: "goerliOptimism",
     color: "#f01a37",
-    chainId: 420,
+    id: 420,
   },
   optimism: {
     name: "optimism",
     color: "#f01a37",
-    chainId: 10,
+    id: 10,
   },
   goerliArbitrum: {
     name: "goerliArbitrum",
     color: "#28a0f0",
-    chainId: 421613,
+    id: 421613,
   },
   arbitrum: {
     name: "arbitrum",
     color: "#28a0f0",
-    chainId: 42161,
+    id: 42161,
   },
   devnetArbitrum: {
     name: "devnetArbitrum",
     color: "#28a0f0",
-    chainId: 421612,
+    id: 421612,
   },
   localAvalanche: {
     name: "localAvalanche",
     color: ["#666666", "#bbbbbb"],
-    chainId: 43112,
+    id: 43112,
   },
   fujiAvalanche: {
     name: "fujiAvalanche",
     color: ["#666666", "#bbbbbb"],
-    chainId: 43113,
+    id: 43113,
   },
   mainnetAvalanche: {
     name: "mainnetAvalanche",
     color: ["#666666", "#bbbbbb"],
-    chainId: 43114,
+    id: 43114,
   },
   testnetHarmony: {
     name: "testnetHarmony",
     color: "#00b0ef",
-    chainId: 1666700000,
+    id: 1666700000,
   },
   mainnetHarmony: {
     name: "mainnetHarmony",
     color: "#00b0ef",
-    chainId: 1666600000,
+    id: 1666600000,
   },
   fantom: {
     name: "fantom",
     color: "#1969ff",
-    chainId: 250,
+    id: 250,
   },
   testnetFantom: {
     name: "testnetFantom",
     color: "#1969ff",
-    chainId: 4002,
+    id: 4002,
   },
   moonbeam: {
     name: "moonbeam",
     color: "#53CBC9",
-    chainId: 1284,
+    id: 1284,
   },
   moonriver: {
     name: "moonriver",
     color: "#53CBC9",
-    chainId: 1285,
+    id: 1285,
   },
   moonbaseAlpha: {
     name: "moonbaseAlpha",
     color: "#53CBC9",
-    chainId: 1287,
+    id: 1287,
   },
   moonbeamDevNode: {
     name: "moonbeamDevNode",
     color: "#53CBC9",
-    chainId: 1281,
+    id: 1281,
   },
 };
 
@@ -160,21 +159,19 @@ export function getBlockExplorerTxLink(network: Network, txnHash: string) {
   return blockExplorerTxURL;
 }
 
-export const getNetworkDetailsByChainId = (chainId: number) =>
-  Object.values(NETWORKS).find(val => val.chainId === chainId);
+export const getNetworkDetailsByChainId = (id: number) => Object.values(NETWORKS).find(val => val.id === id);
 
 /**
  * @dev Returns the target network metadata or defaults to hardhat if the network is unsupported/undefined
  */
 export const getTargetNetwork = () => {
   const network = process.env.NEXT_PUBLIC_NETWORK;
-  const { chains } = appChains;
-  const configuredChain = chains.find(chain => chain.network === network);
+  const configuredChain = NETWORKS[network ?? "hardhat"];
 
-  if (!network || !configuredChain) {
+  if (!configuredChain) {
     // If error defaults to hardhat local network
     console.error("Network name misspelled or unsupported network used in process.env");
-    const hardhatChain = chains[0];
+    const hardhatChain = NETWORKS["hardhat"];
     return hardhatChain;
   }
 


### PR DESCRIPTION
Because of the naming of mainnet in wagmi/rainbowkit (homestead), when `NEXT_PUBLIC_NETWORK` was "mainnet" it wasn't working. Using `homestead` on `NEXT_PUBLIC_NETWORK` wasn't working either (because our logic).

![photo1676659213](https://user-images.githubusercontent.com/2486142/219768160-0cc7407d-a726-42f0-9ced-dd6df0331648.jpeg)
![photo1676659144](https://user-images.githubusercontent.com/2486142/219768167-7ec3ee5b-7bd0-4fc3-95c6-a977028843c8.jpeg)

---

This is kind of time sensitive so I created this hotfix. Merging it and hoping not to break anything :angel: 

We need to think how to handle networks better and define a source of truth for networks (maybe our `networks.ts`?). 

Also refactor things like this (and use our `getTargetNetwork`):

![image](https://user-images.githubusercontent.com/2486142/219768639-6e33d60b-e472-4174-b8d8-bf802960dee1.png)


This is also related to #168

Let's review this next week @technophile-04 @rin-st 
