### PR TITLE
handle edge-case for getTargetNetwork

### DIFF
--- a/packages/nextjs/utils/scaffold-eth/networks.ts
+++ b/packages/nextjs/utils/scaffold-eth/networks.ts
@@ -166,14 +166,13 @@ export const getNetworkDetailsByChainId = (id: number) => Object.values(NETWORKS
  */
 export const getTargetNetwork = () => {
   const network = process.env.NEXT_PUBLIC_NETWORK;
-  const configuredChain = NETWORKS[network ?? "hardhat"];
 
-  if (!configuredChain) {
+  if (!network || !NETWORKS[network]) {
     // If error defaults to hardhat local network
     console.error("Network name misspelled or unsupported network used in process.env");
     const hardhatChain = NETWORKS["hardhat"];
     return hardhatChain;
   }
 
-  return configuredChain;
+  return NETWORKS[network];
 };

--- a/packages/nextjs/utils/scaffold-eth/networks.ts
+++ b/packages/nextjs/utils/scaffold-eth/networks.ts
@@ -169,7 +169,7 @@ export const getTargetNetwork = () => {
 
   if (!network || !NETWORKS[network]) {
     // If error defaults to hardhat local network
-    console.error("Network name misspelled or unsupported network used in process.env");
+    console.error("Network name is not set, misspelled or unsupported network used in .env.*");
     const hardhatChain = NETWORKS["hardhat"];
     return hardhatChain;
   }


### PR DESCRIPTION
### Desc 
There are very less chances that dev might delete `NEXT_PUBLIC_NETWORK` from `env` but if he does so then he won't get any error in the console and network will be set to `hardhat` without letting him know 

Originally discussed here -> https://github.com/scaffold-eth/se-2/pull/182/files#r1111042625