### PR TITLE
Supported networks

### DIFF
--- a/packages/nextjs/.env.development
+++ b/packages/nextjs/.env.development
@@ -1,6 +1,5 @@
 # The network where your DApp lives in.
-# mainnet / hardhat / polygon / optimism / arbitrum / goerli
+# mainnet / hardhat / polygon / optimism / arbitrum / goerli / sepolia
 # Check supported chains - https://wagmi.sh/core/chains#supported-chains
 NEXT_PUBLIC_NETWORK=hardhat
-NEXT_PUBLIC_ENABLE_TESTNETS=true
 NEXT_PUBLIC_RPC_POLLING_INTERVAL=30000

--- a/packages/nextjs/.env.production
+++ b/packages/nextjs/.env.production
@@ -1,6 +1,5 @@
 # The network where your DApp lives in.
-# mainnet / hardhat / polygon / optimism / arbitrum / goerli
+# mainnet / hardhat / polygon / optimism / arbitrum / goerli / sepolia
 # Check supported chains - https://wagmi.sh/core/chains#supported-chains
 NEXT_PUBLIC_NETWORK=mainnet
-NEXT_PUBLIC_ENABLE_TESTNETS=true
 NEXT_PUBLIC_RPC_POLLING_INTERVAL=30000

--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton.tsx
@@ -57,7 +57,7 @@ export default function RainbowKitCustomConnectButton() {
               return (
                 <div className="px-2 flex justify-end items-center">
                   <div className="flex justify-center items-center border-1 rounded-lg">
-                    <div className="hidden sm:flex flex-col items-center">
+                    <div className="flex flex-col items-center">
                       <Balance address={account.address} className="min-h-0 h-auto" />
                       <span className="text-xs" style={{ color: networkColor }}>
                         {chain.name}

--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton.tsx
@@ -1,7 +1,6 @@
-import Image from "next/image";
 import { ConnectButton } from "@rainbow-me/rainbowkit";
 import { ChevronDownIcon } from "@heroicons/react/24/solid";
-import { TAutoConnect, useAutoConnect } from "~~/hooks/scaffold-eth";
+import { TAutoConnect, useAutoConnect, useNetworkColor } from "~~/hooks/scaffold-eth";
 import Balance from "~~/components/scaffold-eth/Balance";
 import { useSwitchNetwork } from "wagmi";
 import { BlockieAvatar } from "~~/components/scaffold-eth";
@@ -21,6 +20,7 @@ export default function RainbowKitCustomConnectButton() {
   const { switchNetwork } = useSwitchNetwork();
 
   const configuredChain = getTargetNetwork();
+  const networkColor = useNetworkColor();
 
   const onSwitchNetwork = () => {
     switchNetwork?.(configuredChain.id);
@@ -28,9 +28,8 @@ export default function RainbowKitCustomConnectButton() {
 
   return (
     <ConnectButton.Custom>
-      {({ account, chain, openAccountModal, openChainModal, openConnectModal, mounted }) => {
-        const ready = mounted;
-        const connected = ready && account && chain;
+      {({ account, chain, openAccountModal, openConnectModal, mounted }) => {
+        const connected = mounted && account && chain;
 
         return (
           <>
@@ -57,27 +56,12 @@ export default function RainbowKitCustomConnectButton() {
 
               return (
                 <div className="px-2 flex justify-end items-center">
-                  <button
-                    onClick={openChainModal}
-                    className="btn btn-secondary btn-sm font-normal mr-2 sm:mr-0"
-                    type="button"
-                  >
-                    {chain.hasIcon && (
-                      <div className="mt-1">
-                        {chain.iconUrl && (
-                          <Image alt={chain.name ?? "Chain icon"} src={chain.iconUrl} width="20" height="20" />
-                        )}
-                      </div>
-                    )}
-                    <span className="m-2 hidden sm:inline">{chain.name}</span>
-                    <span>
-                      <ChevronDownIcon className="h-6 w-4 ml-2 sm:ml-0" />
-                    </span>
-                  </button>
-
                   <div className="flex justify-center items-center border-1 rounded-lg">
-                    <div className="hidden sm:inline-block">
-                      <Balance address={account.address} />
+                    <div className="hidden sm:flex flex-col items-center">
+                      <Balance address={account.address} className="min-h-0 h-auto" />
+                      <span className="text-xs" style={{ color: networkColor }}>
+                        {chain.name}
+                      </span>
                     </div>
                     <button onClick={openAccountModal} type="button" className="btn btn-primary btn-sm pl-2 shadow-md">
                       <BlockieAvatar address={account.address} size={24} ensImage={account.ensAvatar} />

--- a/packages/nextjs/hooks/scaffold-eth/useNetworkColor.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useNetworkColor.ts
@@ -1,4 +1,4 @@
-import { getTargetNetwork, NETWORKS } from "~~/utils/scaffold-eth";
+import { getTargetNetwork, NETWORKS_EXTRA_DATA } from "~~/utils/scaffold-eth";
 import { useDarkMode } from "usehooks-ts";
 
 /**
@@ -7,7 +7,7 @@ import { useDarkMode } from "usehooks-ts";
 export const useNetworkColor = () => {
   const { isDarkMode } = useDarkMode();
   const configuredChain = getTargetNetwork();
-  const networkDetails = NETWORKS[configuredChain.name];
+  const networkDetails = NETWORKS_EXTRA_DATA[configuredChain.name];
 
   return Array.isArray(networkDetails.color)
     ? isDarkMode

--- a/packages/nextjs/hooks/scaffold-eth/useNetworkColor.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useNetworkColor.ts
@@ -1,5 +1,7 @@
-import { DEFAULT_NETWORK_COLOR, getTargetNetwork, NETWORKS_EXTRA_DATA } from "~~/utils/scaffold-eth";
+import { getTargetNetwork, NETWORKS_EXTRA_DATA } from "~~/utils/scaffold-eth";
 import { useDarkMode } from "usehooks-ts";
+
+const DEFAULT_NETWORK_COLOR: [string, string] = ["#666666", "#bbbbbb"];
 
 /**
  * Gets the color of the target network

--- a/packages/nextjs/hooks/scaffold-eth/useNetworkColor.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useNetworkColor.ts
@@ -1,4 +1,4 @@
-import { getTargetNetwork, NETWORKS_EXTRA_DATA } from "~~/utils/scaffold-eth";
+import { DEFAULT_NETWORK_COLOR, getTargetNetwork, NETWORKS_EXTRA_DATA } from "~~/utils/scaffold-eth";
 import { useDarkMode } from "usehooks-ts";
 
 /**
@@ -7,7 +7,7 @@ import { useDarkMode } from "usehooks-ts";
 export const useNetworkColor = () => {
   const { isDarkMode } = useDarkMode();
   const configuredChain = getTargetNetwork();
-  const networkDetails = NETWORKS_EXTRA_DATA[configuredChain.id];
+  const networkDetails = NETWORKS_EXTRA_DATA[configuredChain.id] ?? { color: DEFAULT_NETWORK_COLOR };
 
   return Array.isArray(networkDetails.color)
     ? isDarkMode

--- a/packages/nextjs/hooks/scaffold-eth/useNetworkColor.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useNetworkColor.ts
@@ -7,7 +7,7 @@ import { useDarkMode } from "usehooks-ts";
 export const useNetworkColor = () => {
   const { isDarkMode } = useDarkMode();
   const configuredChain = getTargetNetwork();
-  const networkDetails = NETWORKS_EXTRA_DATA[configuredChain.name];
+  const networkDetails = NETWORKS_EXTRA_DATA[configuredChain.id];
 
   return Array.isArray(networkDetails.color)
     ? isDarkMode

--- a/packages/nextjs/hooks/scaffold-eth/useNetworkColor.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useNetworkColor.ts
@@ -1,4 +1,4 @@
-import { getTargetNetwork } from "~~/utils/scaffold-eth";
+import { getTargetNetwork, NETWORKS } from "~~/utils/scaffold-eth";
 import { useDarkMode } from "usehooks-ts";
 
 /**
@@ -6,7 +6,8 @@ import { useDarkMode } from "usehooks-ts";
  */
 export const useNetworkColor = () => {
   const { isDarkMode } = useDarkMode();
-  const networkDetails = getTargetNetwork();
+  const configuredChain = getTargetNetwork();
+  const networkDetails = NETWORKS[configuredChain.name];
 
   return Array.isArray(networkDetails.color)
     ? isDarkMode

--- a/packages/nextjs/services/web3/wagmiConnectors.tsx
+++ b/packages/nextjs/services/web3/wagmiConnectors.tsx
@@ -8,25 +8,21 @@ import {
   ledgerWallet,
 } from "@rainbow-me/rainbowkit/wallets";
 import { configureChains } from "wagmi";
-import { mainnet, polygon, optimism, arbitrum, hardhat, localhost, goerli, polygonMumbai } from "wagmi/chains";
+import * as chains from "wagmi/chains";
 import { alchemyProvider } from "wagmi/providers/alchemy";
 import { publicProvider } from "wagmi/providers/public";
 import { burnerWalletConfig } from "~~/services/web3/wagmi-burner/burnerWalletConfig";
+import { getTargetNetwork } from "~~/utils/scaffold-eth";
+
+const configuredChain = getTargetNetwork();
+// We always want to have mainnet enabled (ENS resolution, ETH price, etc). But only once.
+const enabledChains = configuredChain.id === 1 ? [configuredChain] : [configuredChain, chains.mainnet];
 
 /**
- * chains for the app
+ * Chains for the app
  */
 export const appChains = configureChains(
-  [
-    hardhat,
-    mainnet,
-    polygon,
-    optimism,
-    arbitrum,
-    polygon,
-    // todo replace with config instead of env
-    ...(process.env.NEXT_PUBLIC_ENABLE_TESTNETS === "true" ? [goerli, polygonMumbai] : []),
-  ],
+  enabledChains,
   [
     alchemyProvider({
       // ToDo. Move to .env || scaffold config
@@ -54,7 +50,7 @@ export const appChains = configureChains(
  * list of burner wallet compatable chains
  */
 export const burnerChains = configureChains(
-  [localhost, hardhat],
+  [chains.hardhat],
   [
     alchemyProvider({
       // ToDo. Move to .env || scaffold config

--- a/packages/nextjs/utils/scaffold-eth/networks.ts
+++ b/packages/nextjs/utils/scaffold-eth/networks.ts
@@ -1,3 +1,4 @@
+import * as chains from "wagmi/chains";
 import { Network } from "@ethersproject/networks";
 
 export type TChainAttributes = {
@@ -164,17 +165,16 @@ export function getBlockExplorerTxLink(network: Network, txnHash: string) {
 export const getNetworkDetailsByChainId = (id: number) => Object.values(NETWORKS).find(val => val.id === id);
 
 /**
- * @dev Returns the target network metadata or defaults to hardhat if the network is unsupported/undefined
+ * Get the wagmi's Chain target network configured in the app.
  */
 export const getTargetNetwork = () => {
-  const network = process.env.NEXT_PUBLIC_NETWORK;
+  const network = process.env.NEXT_PUBLIC_NETWORK as keyof typeof chains;
 
-  if (!network || !NETWORKS[network]) {
+  if (!network || !chains[network]) {
     // If error defaults to hardhat local network
     console.error("Network name is not set, misspelled or unsupported network used in .env.*");
-    const hardhatChain = NETWORKS["hardhat"];
-    return hardhatChain;
+    return chains.hardhat;
   }
 
-  return NETWORKS[network];
+  return chains[network];
 };

--- a/packages/nextjs/utils/scaffold-eth/networks.ts
+++ b/packages/nextjs/utils/scaffold-eth/networks.ts
@@ -8,12 +8,10 @@ export type TChainAttributes = {
   id: number;
 };
 
-export const DEFAULT_NETWORK_COLOR: [string, string] = ["#666666", "#bbbbbb"];
-
 export const NETWORKS_EXTRA_DATA: Record<string, TChainAttributes> = {
   [chains.hardhat.id]: {
     name: "hardhat",
-    color: DEFAULT_NETWORK_COLOR,
+    color: "#b8af0c",
     id: 31337,
   },
   [chains.mainnet.id]: {
@@ -60,16 +58,6 @@ export const NETWORKS_EXTRA_DATA: Record<string, TChainAttributes> = {
     name: "arbitrum",
     color: "#28a0f0",
     id: 42161,
-  },
-  [chains.avalancheFuji.id]: {
-    name: "fujiAvalanche",
-    color: DEFAULT_NETWORK_COLOR,
-    id: 43113,
-  },
-  [chains.avalanche.id]: {
-    name: "mainnetAvalanche",
-    color: DEFAULT_NETWORK_COLOR,
-    id: 43114,
   },
   [chains.fantom.id]: {
     name: "fantom",

--- a/packages/nextjs/utils/scaffold-eth/networks.ts
+++ b/packages/nextjs/utils/scaffold-eth/networks.ts
@@ -10,7 +10,7 @@ export type TChainAttributes = {
 
 export const DEFAULT_NETWORK_COLOR: [string, string] = ["#666666", "#bbbbbb"];
 
-export const NETWORKS: Record<string, TChainAttributes> = {
+export const NETWORKS_EXTRA_DATA: Record<string, TChainAttributes> = {
   hardhat: {
     name: "hardhat",
     color: DEFAULT_NETWORK_COLOR,
@@ -161,8 +161,6 @@ export function getBlockExplorerTxLink(network: Network, txnHash: string) {
 
   return blockExplorerTxURL;
 }
-
-export const getNetworkDetailsByChainId = (id: number) => Object.values(NETWORKS).find(val => val.id === id);
 
 /**
  * Get the wagmi's Chain target network configured in the app.

--- a/packages/nextjs/utils/scaffold-eth/networks.ts
+++ b/packages/nextjs/utils/scaffold-eth/networks.ts
@@ -2,72 +2,46 @@ import * as chains from "wagmi/chains";
 import { Network } from "@ethersproject/networks";
 
 export type TChainAttributes = {
-  name: string;
   // color | [lightThemeColor, darkThemeColor]
   color: string | [string, string];
-  id: number;
 };
 
 export const NETWORKS_EXTRA_DATA: Record<string, TChainAttributes> = {
   [chains.hardhat.id]: {
-    name: "hardhat",
     color: "#b8af0c",
-    id: 31337,
   },
   [chains.mainnet.id]: {
-    name: "mainnet",
     color: "#ff8b9e",
-    id: 1,
   },
   [chains.goerli.id]: {
-    name: "goerli",
     color: "#0975F6",
-    id: 5,
   },
   [chains.gnosis.id]: {
-    name: "gnosis",
     color: "#48a9a6",
-    id: 100,
   },
   [chains.polygon.id]: {
-    name: "polygon",
     color: "#2bbdf7",
-    id: 137,
   },
   [chains.polygonMumbai.id]: {
-    name: "mumbai",
     color: "#92D9FA",
-    id: 80001,
   },
   [chains.optimismGoerli.id]: {
-    name: "goerliOptimism",
     color: "#f01a37",
-    id: 420,
   },
   [chains.optimism.id]: {
-    name: "optimism",
     color: "#f01a37",
-    id: 10,
   },
   [chains.arbitrumGoerli.id]: {
-    name: "goerliArbitrum",
     color: "#28a0f0",
-    id: 421613,
   },
   [chains.arbitrum.id]: {
-    name: "arbitrum",
     color: "#28a0f0",
-    id: 42161,
   },
   [chains.fantom.id]: {
-    name: "fantom",
     color: "#1969ff",
-    id: 250,
   },
   [chains.fantomTestnet.id]: {
-    name: "testnetFantom",
     color: "#1969ff",
-    id: 4002,
   },
 };
 

--- a/packages/nextjs/utils/scaffold-eth/networks.ts
+++ b/packages/nextjs/utils/scaffold-eth/networks.ts
@@ -11,125 +11,75 @@ export type TChainAttributes = {
 export const DEFAULT_NETWORK_COLOR: [string, string] = ["#666666", "#bbbbbb"];
 
 export const NETWORKS_EXTRA_DATA: Record<string, TChainAttributes> = {
-  hardhat: {
+  [chains.hardhat.id]: {
     name: "hardhat",
     color: DEFAULT_NETWORK_COLOR,
     id: 31337,
   },
-  mainnet: {
+  [chains.mainnet.id]: {
     name: "mainnet",
     color: "#ff8b9e",
     id: 1,
   },
-  goerli: {
+  [chains.goerli.id]: {
     name: "goerli",
     color: "#0975F6",
     id: 5,
   },
-  gnosis: {
+  [chains.gnosis.id]: {
     name: "gnosis",
     color: "#48a9a6",
     id: 100,
   },
-  polygon: {
+  [chains.polygon.id]: {
     name: "polygon",
     color: "#2bbdf7",
     id: 137,
   },
-  mumbai: {
+  [chains.polygonMumbai.id]: {
     name: "mumbai",
     color: "#92D9FA",
     id: 80001,
   },
-  localOptimismL1: {
-    name: "localOptimismL1",
-    color: "#f01a37",
-    id: 31337,
-  },
-  localOptimism: {
-    name: "localOptimism",
-    color: "#f01a37",
-    id: 420,
-  },
-  goerliOptimism: {
+  [chains.optimismGoerli.id]: {
     name: "goerliOptimism",
     color: "#f01a37",
     id: 420,
   },
-  optimism: {
+  [chains.optimism.id]: {
     name: "optimism",
     color: "#f01a37",
     id: 10,
   },
-  goerliArbitrum: {
+  [chains.arbitrumGoerli.id]: {
     name: "goerliArbitrum",
     color: "#28a0f0",
     id: 421613,
   },
-  arbitrum: {
+  [chains.arbitrum.id]: {
     name: "arbitrum",
     color: "#28a0f0",
     id: 42161,
   },
-  devnetArbitrum: {
-    name: "devnetArbitrum",
-    color: "#28a0f0",
-    id: 421612,
-  },
-  localAvalanche: {
-    name: "localAvalanche",
-    color: DEFAULT_NETWORK_COLOR,
-    id: 43112,
-  },
-  fujiAvalanche: {
+  [chains.avalancheFuji.id]: {
     name: "fujiAvalanche",
     color: DEFAULT_NETWORK_COLOR,
     id: 43113,
   },
-  mainnetAvalanche: {
+  [chains.avalanche.id]: {
     name: "mainnetAvalanche",
     color: DEFAULT_NETWORK_COLOR,
     id: 43114,
   },
-  testnetHarmony: {
-    name: "testnetHarmony",
-    color: "#00b0ef",
-    id: 1666700000,
-  },
-  mainnetHarmony: {
-    name: "mainnetHarmony",
-    color: "#00b0ef",
-    id: 1666600000,
-  },
-  fantom: {
+  [chains.fantom.id]: {
     name: "fantom",
     color: "#1969ff",
     id: 250,
   },
-  testnetFantom: {
+  [chains.fantomTestnet.id]: {
     name: "testnetFantom",
     color: "#1969ff",
     id: 4002,
-  },
-  moonbeam: {
-    name: "moonbeam",
-    color: "#53CBC9",
-    id: 1284,
-  },
-  moonriver: {
-    name: "moonriver",
-    color: "#53CBC9",
-    id: 1285,
-  },
-  moonbaseAlpha: {
-    name: "moonbaseAlpha",
-    color: "#53CBC9",
-    id: 1287,
-  },
-  moonbeamDevNode: {
-    name: "moonbeamDevNode",
-    color: "#53CBC9",
-    id: 1281,
   },
 };
 


### PR DESCRIPTION
Fixes #168 

- We had a mix between our own defined networks (in `networks.ts`) and wagmi networks. In this PR, we are using wagmi networks as the source of truth and using our `NETWORKS` (now `NETWORKS_EXTRA_DATA`) as a way to adding extra metadata to some networks (right now it's only the color, but in the future, it could be: displayName, BlockExplorer, etc)

- Wagmi/Rainbowkit available networks are now only the target app network (`NEXT_PUBLIC_NETWORK`) and mainnet (we need it for ENS resolution, Get ETH price, etc)

- Removed the network switcher (as discussed in #168), but we now show the target network below the balance (thanks Andrea for this!)
![image](https://user-images.githubusercontent.com/2486142/220162489-ccc275c2-89c8-453b-9ce5-3252acc2016b.png)

Would love to hear your thoughts on this @rin-st @technophile-04 and make sure that I'm not missing anything.
