### PR TITLE
fix(types): allow generically set return type for contract read hooks

### DIFF
--- a/packages/nextjs/components/ExampleUi/ContractData.tsx
+++ b/packages/nextjs/components/ExampleUi/ContractData.tsx
@@ -14,14 +14,12 @@ export default function ContractData() {
   const containerRef = useRef<HTMLDivElement>(null);
   const greetingRef = useRef<HTMLDivElement>(null);
 
-  // I guess this is related to: https://github.com/scaffold-eth/se-2/issues/116
-  // Ideally I'd like data to be the right type based on the function name / variable name we are calling.
-  // @ts-expect-error
-  const { data: totalCounter }: { data: BigNumber } = useScaffoldContractRead("YourContract", "totalCounter");
+  const { data: totalCounter } = useScaffoldContractRead<BigNumber>("YourContract", "totalCounter");
 
-  // @ts-expect-error
-  const { data: currentGreeting, isLoading: isGreetingLoading }: { data: string; isLoading: true } =
-    useScaffoldContractRead("YourContract", "greeting");
+  const { data: currentGreeting, isLoading: isGreetingLoading } = useScaffoldContractRead<string>(
+    "YourContract",
+    "greeting",
+  );
 
   useScaffoldEventSubscriber("YourContract", "GreetingChange", (greetingSetter, newGreeting, premium, value) => {
     console.log(greetingSetter, newGreeting, premium, value);

--- a/packages/nextjs/hooks/scaffold-eth/useScaffoldContractRead.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useScaffoldContractRead.ts
@@ -2,6 +2,7 @@ import { useContractRead } from "wagmi";
 import type { Abi } from "abitype";
 import { useDeployedContractInfo } from "./useDeployedContractInfo";
 import { getTargetNetwork } from "~~/utils/scaffold-eth";
+import { BigNumber } from "ethers";
 
 /**
  * @dev wrapper for wagmi's useContractRead hook which loads in deployed contract contract abi, address automatically
@@ -9,7 +10,7 @@ import { getTargetNetwork } from "~~/utils/scaffold-eth";
  * @param functionName - name of the function to be called
  * @param readConfig   - wagmi configurations
  */
-export const useScaffoldContractRead = (
+export const useScaffoldContractRead = <TReturn extends BigNumber | string | boolean = any>(
   contractName: string,
   functionName: string,
   readConfig?: Parameters<typeof useContractRead>[0],
@@ -24,5 +25,7 @@ export const useScaffoldContractRead = (
     abi: deployedContractData?.abi as Abi,
     watch: true,
     ...readConfig,
-  });
+  }) as Omit<ReturnType<typeof useContractRead>, "data"> & {
+    data: TReturn;
+  };
 };


### PR DESCRIPTION
Fixes #189 

I propose keeping it rather simple and clean in a first step. The user should know what the return type is (since he'll use it). He can choose to use the return value as `any`, or he can provide the type if he wants better type-safety.