### PR TITLE
"yarn fork" command for mainnet forking

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "account": "yarn workspace @se-2/hardhat account",
     "chain": "yarn workspace @se-2/hardhat chain",
+    "fork": "yarn workspace @se-2/hardhat fork",
     "deploy": "yarn workspace @se-2/hardhat deploy",
     "compile": "yarn workspace @se-2/hardhat compile",
     "generate": "yarn workspace @se-2/hardhat generate",

--- a/packages/hardhat/hardhat.config.ts
+++ b/packages/hardhat/hardhat.config.ts
@@ -22,6 +22,12 @@ const config: HardhatUserConfig = {
   networks: {
     // View the networks that are pre-configured.
     // If the network you are looking for is not here you can add new network settings
+    hardhat: {
+      forking: {
+        url: `https://eth-mainnet.alchemyapi.io/v2/${providerApiKey}`,
+        enabled: process.env.MAINNET_FORKING_ENABLED === "true",
+      },
+    },
     arbitrum: {
       url: `https://arb-mainnet.g.alchemy.com/v2/${providerApiKey}`,
       accounts: [deployerPrivateKey],

--- a/packages/hardhat/package.json
+++ b/packages/hardhat/package.json
@@ -6,7 +6,7 @@
     "chain": "hardhat node --network hardhat --no-deploy",
     "compile": "hardhat compile",
     "deploy": "hardhat deploy --export-all ../nextjs/generated/hardhat_contracts.json",
-    "fork": "hardhat node --network hardhat --no-deploy --fork https://eth-mainnet.alchemyapi.io/v2/oKxs-03sij-U_N0iOlrSsZFr29-IqbuF",
+    "fork": "MAINNET_FORKING_ENABLED=true hardhat node --network hardhat --no-deploy",
     "generate": "hardhat run scripts/generateAccount.ts",
     "lint": "eslint --config ./.eslintrc.json --ignore-path ./.eslintignore ./*.ts ./deploy/**/*.ts ./scripts/**/*.ts ./test/**/*.ts",
     "lint-staged": "eslint --config ./.eslintrc.json --ignore-path ./.eslintignore",

--- a/packages/hardhat/package.json
+++ b/packages/hardhat/package.json
@@ -6,6 +6,7 @@
     "chain": "hardhat node --network hardhat --no-deploy",
     "compile": "hardhat compile",
     "deploy": "hardhat deploy --export-all ../nextjs/generated/hardhat_contracts.json",
+    "fork": "hardhat node --network hardhat --no-deploy --fork https://eth-mainnet.alchemyapi.io/v2/oKxs-03sij-U_N0iOlrSsZFr29-IqbuF",
     "generate": "hardhat run scripts/generateAccount.ts",
     "lint": "eslint --config ./.eslintrc.json --ignore-path ./.eslintignore ./*.ts ./deploy/**/*.ts ./scripts/**/*.ts ./test/**/*.ts",
     "lint-staged": "eslint --config ./.eslintrc.json --ignore-path ./.eslintignore",


### PR DESCRIPTION
As in SE1, we want to be able to run our local hardhat node with mainnet forking.

Don't feel super happy about putting the API Key on package.json, even if we already exposed it in `hardhat.config.js`. It's a default alchemy key we have for SE1.

It's always about finding the balance between: good practices & easy-to-use/no-config

Thoughts? Any other approaches?

![image](https://user-images.githubusercontent.com/2486142/220316527-9bbb64fa-83d1-458d-905b-bddf66fc1375.png)

---

cc @technophile-04 @rin-st @sverps 

