### PR TITLE
Remove hardcoded gas

### DIFF
--- a/packages/nextjs/hooks/scaffold-eth/useTransactor.tsx
+++ b/packages/nextjs/hooks/scaffold-eth/useTransactor.tsx
@@ -1,6 +1,6 @@
 import { TransactionRequest, TransactionResponse, TransactionReceipt } from "@ethersproject/abstract-provider";
 import { SendTransactionResult } from "@wagmi/core";
-import { BigNumber, ethers, Signer } from "ethers";
+import { Signer } from "ethers";
 import { Deferrable } from "ethers/lib/utils";
 import { useSigner } from "wagmi";
 import { getParsedEthersError } from "~~/components/scaffold-eth/Contract/utilsContract";
@@ -30,10 +30,9 @@ const TxnNotification = ({ message, blockExplorerLink }: { message: string; bloc
 /**
  * Runs TXs showing UI feedback.
  * @param _signer
- * @param gasPrice
  * @dev If signer is provided => dev wants to send a raw tx.
  */
-export const useTransactor = (_signer?: Signer, gasPrice?: number): TTransactionFunc => {
+export const useTransactor = (_signer?: Signer): TTransactionFunc => {
   let signer = _signer;
   const { data } = useSigner();
   if (signer === undefined && data) {
@@ -59,14 +58,6 @@ export const useTransactor = (_signer?: Signer, gasPrice?: number): TTransaction
         // Tx is already prepared by the caller
         transactionResponse = await tx;
       } else if (tx != null) {
-        // Raw tx
-        if (!tx.gasPrice) {
-          tx.gasPrice = gasPrice || ethers.utils.parseUnits("4.1", "gwei");
-        }
-        if (!tx.gasLimit) {
-          tx.gasLimit = BigNumber.from(ethers.utils.hexlify(120000));
-        }
-
         transactionResponse = await signer.sendTransaction(tx);
       } else {
         throw new Error("Incorrect transaction passed to transactor");


### PR DESCRIPTION
I think we inherited this from SE-1. We had issues yesterday while using the transactor to send Goerli tx (we had to manually speed them up from metamask)

1. We don't want to send legacy tx (we want maxPriorityFeePerGas / maxFeePerGas)
2. ethers populate the values when calling sendTransaction on populateTx (asking the network) 
![image](https://user-images.githubusercontent.com/2486142/220942186-86686ead-b523-4183-83e6-171e856e080e.png)

The only use case might be using a weird network that doesn't provide gas fees values. We can leave it for the future (maybe configuring that value on `NETWORKS_EXTRA_DATA` and using it on the transactor`)
