### PR TITLE
Argument "args" on scaffoldContractRead

### DIFF
--- a/packages/nextjs/hooks/scaffold-eth/useScaffoldContractRead.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useScaffoldContractRead.ts
@@ -8,11 +8,13 @@ import { BigNumber } from "ethers";
  * @dev wrapper for wagmi's useContractRead hook which loads in deployed contract contract abi, address automatically
  * @param contractName - deployed contract name
  * @param functionName - name of the function to be called
- * @param readConfig   - wagmi configurations
+ * @param args - args to be passed to the function call
+ * @param readConfig - extra wagmi configuration
  */
 export const useScaffoldContractRead = <TReturn extends BigNumber | string | boolean = any>(
   contractName: string,
   functionName: string,
+  args?: any[],
   readConfig?: Parameters<typeof useContractRead>[0],
 ) => {
   const configuredChain = getTargetNetwork();
@@ -24,6 +26,7 @@ export const useScaffoldContractRead = <TReturn extends BigNumber | string | boo
     address: deployedContractData?.address,
     abi: deployedContractData?.abi as Abi,
     watch: true,
+    args,
     ...readConfig,
   }) as Omit<ReturnType<typeof useContractRead>, "data"> & {
     data: TReturn;


### PR DESCRIPTION
This is kind of a hotfix (until #147 #207 or #200 is merged). That's why I went with `any[]` :D 

On yesterday's hacking session, we realized we couldn't read contract data that require params.

e.g.

```
  const { data } = useScaffoldContractRead("YourContract", "userGreetingCounter", [
    "0xWHATEVER_ADDRESS",
  ]);
```

Technically you could pass it on `readConfig`, but I think this is more clear. Should we also add `writeConfig` on `scaffoldContractWrite`? (we can leave it for other PR)