### PR TITLE
remove restriction for useScaffoldContractRead generic

### DIFF
--- a/packages/nextjs/.env.development
+++ b/packages/nextjs/.env.development
@@ -1,5 +1,5 @@
 # The network where your DApp lives in.
-# mainnet / hardhat / sepolia / polygon / optimism / arbitrum
+# mainnet / hardhat / sepolia / polygon / optimism / arbitrum / polygonMumbai
 # Check supported chains - https://wagmi.sh/core/chains#supported-chains
 NEXT_PUBLIC_NETWORK=hardhat
 NEXT_PUBLIC_RPC_POLLING_INTERVAL=30000

--- a/packages/nextjs/.env.production
+++ b/packages/nextjs/.env.production
@@ -1,5 +1,5 @@
 # The network where your DApp lives in.
-# mainnet / hardhat / sepolia / polygon / optimism / arbitrum
+# mainnet / hardhat / sepolia / polygon / optimism / arbitrum / polygonMumbai
 # Check supported chains - https://wagmi.sh/core/chains#supported-chains
 NEXT_PUBLIC_NETWORK=mainnet
 NEXT_PUBLIC_RPC_POLLING_INTERVAL=30000

--- a/packages/nextjs/hooks/scaffold-eth/useScaffoldContractRead.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useScaffoldContractRead.ts
@@ -2,7 +2,6 @@ import { useContractRead } from "wagmi";
 import type { Abi } from "abitype";
 import { useDeployedContractInfo } from "./useDeployedContractInfo";
 import { getTargetNetwork } from "~~/utils/scaffold-eth";
-import { BigNumber } from "ethers";
 
 /**
  * @dev wrapper for wagmi's useContractRead hook which loads in deployed contract contract abi, address automatically
@@ -11,7 +10,7 @@ import { BigNumber } from "ethers";
  * @param args - args to be passed to the function call
  * @param readConfig - extra wagmi configuration
  */
-export const useScaffoldContractRead = <TReturn extends BigNumber | string | boolean = any>(
+export const useScaffoldContractRead = <TReturn = any>(
   contractName: string,
   functionName: string,
   args?: any[],


### PR DESCRIPTION
Noticed it while hacking se-2 : 

1. You are not able to pass other types as generic expect `BigNumber | boolean | string`, I think we should not restrict just to `BigNumber | boolean | string` and allow developers to pass in what they want, since sometime your function may return `struct` or other types. 

2. Added `polygonMumbai` to `.env's`, lots of people use `mumbai` for hacking and it would great if we add reference in comments itself so that developers don't have to go to wagmi's doc (we can completely ignore this though)