### PR TITLE
Fix collapse arrow on tx receipt

### DIFF
--- a/packages/nextjs/components/scaffold-eth/Contract/TxReceipt.tsx
+++ b/packages/nextjs/components/scaffold-eth/Contract/TxReceipt.tsx
@@ -4,7 +4,7 @@ import { displayTxResult } from "./utilsDisplay";
 
 const TxReceipt = (txResult: string | number | BigNumber | Record<string, any> | TransactionReceipt | undefined) => {
   return (
-    <div className="flex-wrap collapse mb-2">
+    <div className="flex-wrap collapse collapse-arrow mb-2">
       <input type="checkbox" className="min-h-0 peer" />
       <div className="collapse-title text-sm rounded-3xl peer-checked:rounded-b-none min-h-0 bg-secondary py-1.5">
         <strong>Transaction Receipt</strong>


### PR DESCRIPTION
Lost the tx receipt arrow on 2fbebaceace89d326b9b24720ff349d8446de687

![image](https://user-images.githubusercontent.com/2486142/224677691-596cab12-146c-4e0f-a9bd-325389a3bfd8.png)

Fix:

![image](https://user-images.githubusercontent.com/2486142/224677818-a61cdbae-4942-4ce9-b53c-cdabef6c12e2.png)

