### PR TITLE
fix: write and read methods keys

### DIFF
--- a/packages/nextjs/components/scaffold-eth/Contract/utilsContract.tsx
+++ b/packages/nextjs/components/scaffold-eth/Contract/utilsContract.tsx
@@ -63,11 +63,17 @@ const getContractReadOnlyMethodsWithParams = (
   return {
     methods: contract
       ? contractMethodsAndVariables
-          .map(fn => {
+          .map((fn, idx) => {
             const isQueryableWithParams =
               (fn.stateMutability === "view" || fn.stateMutability === "pure") && fn.inputs.length > 0;
             if (isQueryableWithParams) {
-              return <ReadOnlyFunctionForm key={fn.name} functionFragment={fn} contractAddress={contract.address} />;
+              return (
+                <ReadOnlyFunctionForm
+                  key={`${fn.name}-${idx}`}
+                  functionFragment={fn}
+                  contractAddress={contract.address}
+                />
+              );
             }
             return null;
           })
@@ -92,12 +98,12 @@ const getContractWriteMethods = (
   return {
     methods: contract
       ? contractMethodsAndVariables
-          .map(fn => {
+          .map((fn, idx) => {
             const isWriteableFunction = fn.stateMutability !== "view" && fn.stateMutability !== "pure";
             if (isWriteableFunction) {
               return (
                 <WriteOnlyFunctionForm
-                  key={fn.name}
+                  key={`${fn.name}-${idx}`}
                   functionFragment={fn}
                   contractAddress={contract.address}
                   setRefreshDisplayVariables={setRefreshDisplayVariables}


### PR DESCRIPTION
In some cases, we can have function overloads in solidity contracts, for example when using
`contract Abc is ERC721Enumerable`

<img width="1538" alt="image" src="https://user-images.githubusercontent.com/25638585/224717398-6f27b944-4f30-4680-a4ca-bdbeb5c18c8a.png">
