### PR TITLE
Use .config for frontend instaed of env's

### DIFF
--- a/packages/nextjs/.env.development
+++ b/packages/nextjs/.env.development
@@ -1,5 +1,0 @@
-# The network where your DApp lives in.
-# mainnet / hardhat / sepolia / polygon / optimism / arbitrum / polygonMumbai
-# Check supported chains - https://wagmi.sh/core/chains#supported-chains
-NEXT_PUBLIC_NETWORK=hardhat
-NEXT_PUBLIC_RPC_POLLING_INTERVAL=30000

--- a/packages/nextjs/.env.production
+++ b/packages/nextjs/.env.production
@@ -1,6 +1,0 @@
-# The network where your DApp lives in.
-# mainnet / hardhat / sepolia / polygon / optimism / arbitrum / polygonMumbai
-# Check supported chains - https://wagmi.sh/core/chains#supported-chains
-NEXT_PUBLIC_NETWORK=mainnet
-NEXT_PUBLIC_RPC_POLLING_INTERVAL=30000
-NEXT_PUBLIC_IGNORE_BUILD_ERROR=false

--- a/packages/nextjs/components/Footer.tsx
+++ b/packages/nextjs/components/Footer.tsx
@@ -3,15 +3,14 @@ import { CurrencyDollarIcon } from "@heroicons/react/24/outline";
 import { HeartIcon } from "@heroicons/react/24/outline";
 import { SwitchTheme } from "~~/components/SwitchTheme";
 import { Faucet } from "~~/components/scaffold-eth";
+import scaffoldConfig from "~~/scaffold.config";
 import { useAppStore } from "~~/services/store/store";
-import { getTargetNetwork } from "~~/utils/scaffold-eth";
 
 /**
  * Site footer
  */
 export const Footer = () => {
   const ethPrice = useAppStore(state => state.ethPrice);
-  const configuredNetwork = getTargetNetwork();
 
   return (
     <div className="min-h-0 p-5 mb-11 lg:mb-0">
@@ -24,7 +23,7 @@ export const Footer = () => {
                 <span>{ethPrice}</span>
               </div>
             )}
-            {configuredNetwork.id === hardhat.id && <Faucet />}
+            {scaffoldConfig.targetNetwork.id === hardhat.id && <Faucet />}
           </div>
           <SwitchTheme className="pointer-events-auto" />
         </div>

--- a/packages/nextjs/components/scaffold-eth/Contract/ContractUI.tsx
+++ b/packages/nextjs/components/scaffold-eth/Contract/ContractUI.tsx
@@ -11,7 +11,7 @@ import {
   getContractWriteMethods,
 } from "~~/components/scaffold-eth";
 import { useDeployedContractInfo, useNetworkColor } from "~~/hooks/scaffold-eth";
-import { getTargetNetwork } from "~~/utils/scaffold-eth";
+import scaffoldConfig from "~~/scaffold.config";
 
 type TContractUIProps = {
   contractName: string;
@@ -22,7 +22,6 @@ type TContractUIProps = {
  * UI component to interface with deployed contracts.
  **/
 export const ContractUI = ({ contractName, className = "" }: TContractUIProps) => {
-  const configuredChain = getTargetNetwork();
   const provider = useProvider();
   const [refreshDisplayVariables, setRefreshDisplayVariables] = useState(false);
 
@@ -66,7 +65,7 @@ export const ContractUI = ({ contractName, className = "" }: TContractUIProps) =
   if (!contractAddress) {
     return (
       <p className="text-3xl mt-14">
-        {`No contract found by the name of "${contractName}" on chain "${configuredChain.name}"!`}
+        {`No contract found by the name of "${contractName}" on chain "${scaffoldConfig.targetNetwork.name}"!`}
       </p>
     );
   }
@@ -86,10 +85,10 @@ export const ContractUI = ({ contractName, className = "" }: TContractUIProps) =
                 </div>
               </div>
             </div>
-            {configuredChain && (
+            {scaffoldConfig.targetNetwork && (
               <p className="my-0 text-sm">
                 <span className="font-bold">Network</span>:{" "}
-                <span style={{ color: networkColor }}>{configuredChain.name}</span>
+                <span style={{ color: networkColor }}>{scaffoldConfig.targetNetwork.name}</span>
               </p>
             )}
           </div>

--- a/packages/nextjs/components/scaffold-eth/Contract/ContractUI.tsx
+++ b/packages/nextjs/components/scaffold-eth/Contract/ContractUI.tsx
@@ -24,6 +24,7 @@ type TContractUIProps = {
 export const ContractUI = ({ contractName, className = "" }: TContractUIProps) => {
   const provider = useProvider();
   const [refreshDisplayVariables, setRefreshDisplayVariables] = useState(false);
+  const configuredNetwork = scaffoldConfig.targetNetwork;
 
   let contractAddress = "";
   let contractABI = [];
@@ -65,7 +66,7 @@ export const ContractUI = ({ contractName, className = "" }: TContractUIProps) =
   if (!contractAddress) {
     return (
       <p className="text-3xl mt-14">
-        {`No contract found by the name of "${contractName}" on chain "${scaffoldConfig.targetNetwork.name}"!`}
+        {`No contract found by the name of "${contractName}" on chain "${configuredNetwork.name}"!`}
       </p>
     );
   }
@@ -85,10 +86,10 @@ export const ContractUI = ({ contractName, className = "" }: TContractUIProps) =
                 </div>
               </div>
             </div>
-            {scaffoldConfig.targetNetwork && (
+            {configuredNetwork && (
               <p className="my-0 text-sm">
                 <span className="font-bold">Network</span>:{" "}
-                <span style={{ color: networkColor }}>{scaffoldConfig.targetNetwork.name}</span>
+                <span style={{ color: networkColor }}>{configuredNetwork.name}</span>
               </p>
             )}
           </div>

--- a/packages/nextjs/components/scaffold-eth/Contract/DisplayVariable.tsx
+++ b/packages/nextjs/components/scaffold-eth/Contract/DisplayVariable.tsx
@@ -4,7 +4,8 @@ import { useContractRead } from "wagmi";
 import { ArrowPathIcon } from "@heroicons/react/24/outline";
 import { displayTxResult } from "~~/components/scaffold-eth";
 import { useAnimationConfig } from "~~/hooks/scaffold-eth";
-import { getTargetNetwork, notification } from "~~/utils/scaffold-eth";
+import scaffoldConfig from "~~/scaffold.config";
+import { notification } from "~~/utils/scaffold-eth";
 
 type TDisplayVariableProps = {
   functionFragment: FunctionFragment;
@@ -17,13 +18,12 @@ export const DisplayVariable = ({
   functionFragment,
   refreshDisplayVariables,
 }: TDisplayVariableProps) => {
-  const configuredChain = getTargetNetwork();
   const {
     data: result,
     isFetching,
     refetch,
   } = useContractRead({
-    chainId: configuredChain.id,
+    chainId: scaffoldConfig.targetNetwork.id,
     address: contractAddress,
     abi: [functionFragment],
     functionName: functionFragment.name,

--- a/packages/nextjs/components/scaffold-eth/Contract/ReadOnlyFunctionForm.tsx
+++ b/packages/nextjs/components/scaffold-eth/Contract/ReadOnlyFunctionForm.tsx
@@ -7,7 +7,8 @@ import {
   getFunctionInputKey,
   getParsedContractFunctionArgs,
 } from "~~/components/scaffold-eth";
-import { getTargetNetwork, notification } from "~~/utils/scaffold-eth";
+import scaffoldConfig from "~~/scaffold.config";
+import { notification } from "~~/utils/scaffold-eth";
 
 const getInitialFormState = (functionFragment: FunctionFragment) => {
   const initialForm: Record<string, any> = {};
@@ -26,10 +27,9 @@ type TReadOnlyFunctionFormProps = {
 export const ReadOnlyFunctionForm = ({ functionFragment, contractAddress }: TReadOnlyFunctionFormProps) => {
   const [form, setForm] = useState<Record<string, any>>(() => getInitialFormState(functionFragment));
   const [result, setResult] = useState<unknown>();
-  const configuredChain = getTargetNetwork();
 
   const { isFetching, refetch } = useContractRead({
-    chainId: configuredChain.id,
+    chainId: scaffoldConfig.targetNetwork.id,
     address: contractAddress,
     abi: [functionFragment],
     functionName: functionFragment.name,

--- a/packages/nextjs/components/scaffold-eth/Contract/WriteOnlyFunctionForm.tsx
+++ b/packages/nextjs/components/scaffold-eth/Contract/WriteOnlyFunctionForm.tsx
@@ -12,7 +12,8 @@ import {
   getParsedEthersError,
 } from "~~/components/scaffold-eth";
 import { useTransactor } from "~~/hooks/scaffold-eth";
-import { getTargetNetwork, notification, parseTxnValue } from "~~/utils/scaffold-eth";
+import scaffoldConfig from "~~/scaffold.config";
+import { notification, parseTxnValue } from "~~/utils/scaffold-eth";
 
 // TODO set sensible initial state values to avoid error on first render, also put it in utilsContract
 const getInitialFormState = (functionFragment: FunctionFragment) => {
@@ -38,9 +39,8 @@ export const WriteOnlyFunctionForm = ({
   const [form, setForm] = useState<Record<string, any>>(() => getInitialFormState(functionFragment));
   const [txValue, setTxValue] = useState<string | BigNumber>("");
   const { chain } = useNetwork();
-  const configuredChain = getTargetNetwork();
   const writeTxn = useTransactor();
-  const writeDisabled = !chain || chain?.id !== configuredChain.id;
+  const writeDisabled = !chain || chain?.id !== scaffoldConfig.targetNetwork.id;
 
   // We are omitting usePrepareContractWrite here to avoid unnecessary RPC calls and wrong gas estimations.
   // See:

--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton.tsx
@@ -2,7 +2,7 @@ import { ConnectButton } from "@rainbow-me/rainbowkit";
 import { ChevronDownIcon } from "@heroicons/react/24/solid";
 import { Balance, BlockieAvatar } from "~~/components/scaffold-eth";
 import { TAutoConnect, useAutoConnect, useNetworkColor } from "~~/hooks/scaffold-eth";
-import { getTargetNetwork } from "~~/utils/scaffold-eth";
+import scaffoldConfig from "~~/scaffold.config";
 
 // todo: move this later scaffold config.  See TAutoConnect for comments on each prop
 const tempAutoConnectConfig: TAutoConnect = {
@@ -16,7 +16,6 @@ const tempAutoConnectConfig: TAutoConnect = {
 export const RainbowKitCustomConnectButton = () => {
   useAutoConnect(tempAutoConnectConfig);
 
-  const configuredChain = getTargetNetwork();
   const networkColor = useNetworkColor();
 
   return (
@@ -35,11 +34,11 @@ export const RainbowKitCustomConnectButton = () => {
                 );
               }
 
-              if (chain.unsupported || chain.id !== configuredChain.id) {
+              if (chain.unsupported || chain.id !== scaffoldConfig.targetNetwork.id) {
                 return (
                   <>
                     <span className="text-xs" style={{ color: networkColor }}>
-                      {configuredChain.name}
+                      {scaffoldConfig.targetNetwork.name}
                     </span>
                     <button className="btn btn-sm btn-error ml-2" onClick={openChainModal} type="button">
                       <span>Wrong network</span>

--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton.tsx
@@ -17,6 +17,7 @@ export const RainbowKitCustomConnectButton = () => {
   useAutoConnect(tempAutoConnectConfig);
 
   const networkColor = useNetworkColor();
+  const configuredNetwork = scaffoldConfig.targetNetwork;
 
   return (
     <ConnectButton.Custom>
@@ -34,11 +35,11 @@ export const RainbowKitCustomConnectButton = () => {
                 );
               }
 
-              if (chain.unsupported || chain.id !== scaffoldConfig.targetNetwork.id) {
+              if (chain.unsupported || chain.id !== configuredNetwork.id) {
                 return (
                   <>
                     <span className="text-xs" style={{ color: networkColor }}>
-                      {scaffoldConfig.targetNetwork.name}
+                      {configuredNetwork.name}
                     </span>
                     <button className="btn btn-sm btn-error ml-2" onClick={openChainModal} type="button">
                       <span>Wrong network</span>

--- a/packages/nextjs/hooks/scaffold-eth/useAccountBalance.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useAccountBalance.ts
@@ -1,13 +1,12 @@
 import { useCallback, useEffect, useState } from "react";
 import { useBalance } from "wagmi";
+import scaffoldConfig from "~~/scaffold.config";
 import { useAppStore } from "~~/services/store/store";
-import { getTargetNetwork } from "~~/utils/scaffold-eth";
 
 export function useAccountBalance(address?: string) {
   const [isEthBalance, setIsEthBalance] = useState(true);
   const [balance, setBalance] = useState<number | null>(null);
   const price = useAppStore(state => state.ethPrice);
-  const configuredChain = getTargetNetwork();
 
   const {
     data: fetchedBalanceData,
@@ -16,7 +15,7 @@ export function useAccountBalance(address?: string) {
   } = useBalance({
     address,
     watch: true,
-    chainId: configuredChain.id,
+    chainId: scaffoldConfig.targetNetwork.id,
   });
 
   const onToggleBalance = useCallback(() => {

--- a/packages/nextjs/hooks/scaffold-eth/useAutoConnect.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useAutoConnect.ts
@@ -1,6 +1,8 @@
 import { useEffect } from "react";
 import { useEffectOnce, useLocalStorage } from "usehooks-ts";
 import { Connector, useAccount, useConnect } from "wagmi";
+import { hardhat } from "wagmi/dist/chains";
+import scaffoldConfig from "~~/scaffold.config";
 import { burnerWalletId, defaultBurnerChainId } from "~~/services/web3/wagmi-burner/BurnerConnector";
 
 export type TAutoConnect = {
@@ -31,7 +33,7 @@ const getInitialConnector = (
   connectors: Connector<any, any, any>[],
 ): { connector: Connector | undefined; chainId?: number } | undefined => {
   const allowBurner = config.enableBurnerWallet;
-  const isLocalChainSelected = process.env.NEXT_PUBLIC_NETWORK === "hardhat";
+  const isLocalChainSelected = scaffoldConfig.targetNetwork.id === hardhat.id;
 
   if (!previousWalletId) {
     // The user was not connected to a wallet

--- a/packages/nextjs/hooks/scaffold-eth/useAutoConnect.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useAutoConnect.ts
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import { useEffectOnce, useLocalStorage } from "usehooks-ts";
 import { Connector, useAccount, useConnect } from "wagmi";
-import { hardhat } from "wagmi/dist/chains";
+import { hardhat } from "wagmi/chains";
 import scaffoldConfig from "~~/scaffold.config";
 import { burnerWalletId, defaultBurnerChainId } from "~~/services/web3/wagmi-burner/BurnerConnector";
 

--- a/packages/nextjs/hooks/scaffold-eth/useDeployedContractInfo.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useDeployedContractInfo.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { useProvider } from "wagmi";
-import { getTargetNetwork } from "~~/utils/scaffold-eth";
+import scaffoldConfig from "~~/scaffold.config";
 
 type GeneratedContractType = {
   address: string;
@@ -13,10 +13,9 @@ type GeneratedContractType = {
  * @returns {GeneratedContractType | undefined} object containing contract address and abi or undefined if contract is not found
  */
 export const useDeployedContractInfo = (contractName: string | undefined | null) => {
-  const configuredChain = getTargetNetwork();
   const [deployedContractData, setDeployedContractData] = useState<undefined | GeneratedContractType>(undefined);
   const [isLoading, setIsLoading] = useState(true);
-  const provider = useProvider({ chainId: configuredChain.id });
+  const provider = useProvider({ chainId: scaffoldConfig.targetNetwork.id });
 
   useEffect(() => {
     const getDeployedContractInfo = async () => {
@@ -24,7 +23,7 @@ export const useDeployedContractInfo = (contractName: string | undefined | null)
       let ContractData;
       try {
         ContractData = require("~~/generated/hardhat_contracts.json");
-        const contractsAtChain = ContractData[configuredChain.id as keyof typeof ContractData];
+        const contractsAtChain = ContractData[scaffoldConfig.targetNetwork.id as keyof typeof ContractData];
         const contractsData = contractsAtChain?.[0]?.contracts;
         const deployedContract = contractsData?.[contractName as keyof typeof contractsData];
 
@@ -47,7 +46,7 @@ export const useDeployedContractInfo = (contractName: string | undefined | null)
     };
 
     getDeployedContractInfo();
-  }, [configuredChain.id, contractName, provider]);
+  }, [contractName, provider]);
 
   return { data: deployedContractData, isLoading };
 };

--- a/packages/nextjs/hooks/scaffold-eth/useDeployedContractInfo.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useDeployedContractInfo.ts
@@ -15,7 +15,9 @@ type GeneratedContractType = {
 export const useDeployedContractInfo = (contractName: string | undefined | null) => {
   const [deployedContractData, setDeployedContractData] = useState<undefined | GeneratedContractType>(undefined);
   const [isLoading, setIsLoading] = useState(true);
-  const provider = useProvider({ chainId: scaffoldConfig.targetNetwork.id });
+  const configuredNetwork = scaffoldConfig.targetNetwork;
+
+  const provider = useProvider({ chainId: configuredNetwork.id });
 
   useEffect(() => {
     const getDeployedContractInfo = async () => {
@@ -23,7 +25,7 @@ export const useDeployedContractInfo = (contractName: string | undefined | null)
       let ContractData;
       try {
         ContractData = require("~~/generated/hardhat_contracts.json");
-        const contractsAtChain = ContractData[scaffoldConfig.targetNetwork.id as keyof typeof ContractData];
+        const contractsAtChain = ContractData[configuredNetwork.id as keyof typeof ContractData];
         const contractsData = contractsAtChain?.[0]?.contracts;
         const deployedContract = contractsData?.[contractName as keyof typeof contractsData];
 
@@ -46,7 +48,7 @@ export const useDeployedContractInfo = (contractName: string | undefined | null)
     };
 
     getDeployedContractInfo();
-  }, [contractName, provider]);
+  }, [configuredNetwork.id, contractName, provider]);
 
   return { data: deployedContractData, isLoading };
 };

--- a/packages/nextjs/hooks/scaffold-eth/useDeployedContractNames.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useDeployedContractNames.ts
@@ -1,19 +1,18 @@
 import { useEffect, useState } from "react";
-import { getTargetNetwork } from "~~/utils/scaffold-eth";
+import scaffoldConfig from "~~/scaffold.config";
 
 /**
  * @dev use this hook to get the list of contracts deployed by `yarn deploy`.
  * @returns {string[]} array of contract names
  */
 export const useDeployedContractNames = () => {
-  const configuredChain = getTargetNetwork();
   const [deployedContractNames, setDeployedContractNames] = useState<string[]>([]);
 
   useEffect(() => {
     try {
       // eslint-disable-next-line @typescript-eslint/no-var-requires
       const contracts = require("~~/generated/hardhat_contracts.json");
-      const contractsAtChain = contracts[`${configuredChain.id}` as keyof typeof contracts];
+      const contractsAtChain = contracts[`${scaffoldConfig.targetNetwork.id}` as keyof typeof contracts];
       const contractsData = contractsAtChain?.[0]?.contracts;
       const contractNames = contractsData ? Object.keys(contractsData) : [];
 
@@ -22,7 +21,7 @@ export const useDeployedContractNames = () => {
       // File doesn't exist.
       setDeployedContractNames([]);
     }
-  }, [configuredChain.id]);
+  }, []);
 
   return deployedContractNames;
 };

--- a/packages/nextjs/hooks/scaffold-eth/useEthPrice.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useEthPrice.ts
@@ -1,12 +1,10 @@
 import { useEffect, useState } from "react";
 import { useInterval } from "usehooks-ts";
 import { useProvider } from "wagmi";
+import scaffoldConfig from "~~/scaffold.config";
 import { fetchPriceFromUniswap } from "~~/utils/scaffold-eth";
 
 const enablePolling = false;
-const pollingTime = process.env.NEXT_PUBLIC_RPC_POLLING_INTERVAL
-  ? parseInt(process.env.NEXT_PUBLIC_RPC_POLLING_INTERVAL)
-  : 30_000;
 
 /**
  * Get the price of ETH based on ETH/DAI trading pair from Uniswap SDK
@@ -30,7 +28,7 @@ export const useEthPrice = () => {
       const price = await fetchPriceFromUniswap(provider);
       setEthPrice(price);
     },
-    enablePolling ? pollingTime : null,
+    enablePolling ? scaffoldConfig.pollingInterval : null,
   );
 
   return ethPrice;

--- a/packages/nextjs/hooks/scaffold-eth/useNetworkColor.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useNetworkColor.ts
@@ -1,5 +1,6 @@
 import { useDarkMode } from "usehooks-ts";
-import { NETWORKS_EXTRA_DATA, getTargetNetwork } from "~~/utils/scaffold-eth";
+import scaffoldConfig from "~~/scaffold.config";
+import { NETWORKS_EXTRA_DATA } from "~~/utils/scaffold-eth";
 
 const DEFAULT_NETWORK_COLOR: [string, string] = ["#666666", "#bbbbbb"];
 
@@ -8,8 +9,7 @@ const DEFAULT_NETWORK_COLOR: [string, string] = ["#666666", "#bbbbbb"];
  */
 export const useNetworkColor = () => {
   const { isDarkMode } = useDarkMode();
-  const configuredChain = getTargetNetwork();
-  const networkDetails = NETWORKS_EXTRA_DATA[configuredChain.id] ?? { color: DEFAULT_NETWORK_COLOR };
+  const networkDetails = NETWORKS_EXTRA_DATA[scaffoldConfig.targetNetwork.id] ?? { color: DEFAULT_NETWORK_COLOR };
 
   return Array.isArray(networkDetails.color)
     ? isDarkMode

--- a/packages/nextjs/hooks/scaffold-eth/useScaffoldContractRead.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useScaffoldContractRead.ts
@@ -1,7 +1,7 @@
 import type { Abi } from "abitype";
 import { useContractRead } from "wagmi";
 import { useDeployedContractInfo } from "~~/hooks/scaffold-eth";
-import { getTargetNetwork } from "~~/utils/scaffold-eth";
+import scaffoldConfig from "~~/scaffold.config";
 
 /**
  * @dev wrapper for wagmi's useContractRead hook which loads in deployed contract contract abi, address automatically
@@ -16,11 +16,10 @@ export const useScaffoldContractRead = <TReturn = any>(
   args?: any[],
   readConfig?: Parameters<typeof useContractRead>[0],
 ) => {
-  const configuredChain = getTargetNetwork();
   const { data: deployedContractData } = useDeployedContractInfo(contractName);
 
   return useContractRead({
-    chainId: configuredChain.id,
+    chainId: scaffoldConfig.targetNetwork.id,
     functionName,
     address: deployedContractData?.address,
     abi: deployedContractData?.abi as Abi,

--- a/packages/nextjs/hooks/scaffold-eth/useScaffoldContractWrite.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useScaffoldContractWrite.ts
@@ -2,7 +2,8 @@ import { utils } from "ethers";
 import { useContractWrite, useNetwork } from "wagmi";
 import { getParsedEthersError } from "~~/components/scaffold-eth";
 import { useDeployedContractInfo, useTransactor } from "~~/hooks/scaffold-eth";
-import { getTargetNetwork, notification } from "~~/utils/scaffold-eth";
+import scaffoldConfig from "~~/scaffold.config";
+import { notification } from "~~/utils/scaffold-eth";
 
 /**
  * @dev wrapper for wagmi's useContractWrite hook(with config prepared by usePrepareContractWrite hook) which loads in deployed contract abi and address automatically
@@ -12,14 +13,13 @@ import { getTargetNetwork, notification } from "~~/utils/scaffold-eth";
  * @param value - value in ETH that will be sent with transaction
  */
 export const useScaffoldContractWrite = (contractName: string, functionName: string, args?: any[], value?: string) => {
-  const configuredChain = getTargetNetwork();
   const { data: deployedContractData } = useDeployedContractInfo(contractName);
   const { chain } = useNetwork();
   const writeTx = useTransactor();
 
   const wagmiContractWrite = useContractWrite({
     mode: "recklesslyUnprepared",
-    chainId: configuredChain.id,
+    chainId: scaffoldConfig.targetNetwork.id,
     address: deployedContractData?.address,
     abi: deployedContractData?.abi,
     args,
@@ -38,7 +38,7 @@ export const useScaffoldContractWrite = (contractName: string, functionName: str
       notification.error("Please connect your wallet");
       return;
     }
-    if (chain?.id !== configuredChain.id) {
+    if (chain?.id !== scaffoldConfig.targetNetwork.id) {
       notification.error("You on the wrong network");
       return;
     }

--- a/packages/nextjs/hooks/scaffold-eth/useScaffoldContractWrite.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useScaffoldContractWrite.ts
@@ -18,10 +18,11 @@ export const useScaffoldContractWrite = (contractName: string, functionName: str
   const { chain } = useNetwork();
   const writeTx = useTransactor();
   const [isMining, setIsMining] = useState(false);
+  const configuredNetwork = scaffoldConfig.targetNetwork;
 
   const wagmiContractWrite = useContractWrite({
     mode: "recklesslyUnprepared",
-    chainId: scaffoldConfig.targetNetwork.id,
+    chainId: configuredNetwork.id,
     address: deployedContractData?.address,
     abi: deployedContractData?.abi,
     args,
@@ -40,7 +41,7 @@ export const useScaffoldContractWrite = (contractName: string, functionName: str
       notification.error("Please connect your wallet");
       return;
     }
-    if (chain?.id !== scaffoldConfig.targetNetwork.id) {
+    if (chain?.id !== configuredNetwork.id) {
       notification.error("You on the wrong network");
       return;
     }

--- a/packages/nextjs/hooks/scaffold-eth/useScaffoldEventSubscriber.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useScaffoldEventSubscriber.ts
@@ -1,6 +1,6 @@
 import { useContractEvent } from "wagmi";
 import { useDeployedContractInfo } from "~~/hooks/scaffold-eth";
-import { getTargetNetwork } from "~~/utils/scaffold-eth";
+import scaffoldConfig from "~~/scaffold.config";
 
 /**
  * @dev wrapper for wagmi's useContractEvent
@@ -15,13 +15,12 @@ export const useScaffoldEventSubscriber = (
   callbackListener: (...args: unknown[]) => void,
   once = false,
 ) => {
-  const configuredChain = getTargetNetwork();
   const { data: deployedContractData } = useDeployedContractInfo(contractName);
 
   return useContractEvent({
     address: deployedContractData?.address,
     abi: deployedContractData?.abi,
-    chainId: configuredChain.id,
+    chainId: scaffoldConfig.targetNetwork.id,
     listener: callbackListener,
     eventName,
     once,

--- a/packages/nextjs/scaffold.config.ts
+++ b/packages/nextjs/scaffold.config.ts
@@ -1,14 +1,14 @@
-import * as chain from "wagmi/chains";
+import * as chains from "wagmi/chains";
 
 type ScaffoldConfig = {
-  targetNetwork: chain.Chain;
+  targetNetwork: chains.Chain;
   pollingInterval: number;
   alchemyApiKey: string;
 };
 
 const scaffoldConfig: ScaffoldConfig = {
   // The network where your DApp lives in
-  targetNetwork: chain.hardhat,
+  targetNetwork: chains.hardhat,
 
   // The interval at which your front-end polls the RPC servers for new data
   // it has no effect on the local network

--- a/packages/nextjs/scaffold.config.ts
+++ b/packages/nextjs/scaffold.config.ts
@@ -8,7 +8,7 @@ type ScaffoldConfig = {
 
 const scaffoldConfig: ScaffoldConfig = {
   // The network where your DApp lives in
-  targetNetwork: chains.goerli,
+  targetNetwork: chains.hardhat,
 
   // The interval at which your front-end polls the RPC servers for new data
   // it has no effect on the local network

--- a/packages/nextjs/scaffold.config.ts
+++ b/packages/nextjs/scaffold.config.ts
@@ -16,6 +16,8 @@ const scaffoldConfig: ScaffoldConfig = {
 
   // This is ours Alchemy's default API key.
   // You can get your own at https://dashboard.alchemyapi.io
+  // It's recommended to store it in an env variable:
+  // .env.local for local testing, and in the Vercel/system env config for live apps.
   alchemyApiKey: process.env.NEXT_PUBLIC_ALCHEMY_API_KEY || "oKxs-03sij-U_N0iOlrSsZFr29-IqbuF",
 } as const;
 

--- a/packages/nextjs/scaffold.config.ts
+++ b/packages/nextjs/scaffold.config.ts
@@ -16,7 +16,7 @@ const scaffoldConfig: ScaffoldConfig = {
 
   // This is ours Alchemy's default API key.
   // You can get your own at https://dashboard.alchemyapi.io
-  alchemyApiKey: "oKxs-03sij-U_N0iOlrSsZFr29-IqbuF",
+  alchemyApiKey: process.env.NEXT_PUBLIC_ALCHEMY_API_KEY || "oKxs-03sij-U_N0iOlrSsZFr29-IqbuF",
 } as const;
 
 export default scaffoldConfig;

--- a/packages/nextjs/scaffold.config.ts
+++ b/packages/nextjs/scaffold.config.ts
@@ -8,7 +8,7 @@ type ScaffoldConfig = {
 
 const scaffoldConfig: ScaffoldConfig = {
   // The network where your DApp lives in
-  targetNetwork: chains.hardhat,
+  targetNetwork: chains.goerli,
 
   // The interval at which your front-end polls the RPC servers for new data
   // it has no effect on the local network

--- a/packages/nextjs/scaffold.config.ts
+++ b/packages/nextjs/scaffold.config.ts
@@ -1,0 +1,22 @@
+import * as chain from "wagmi/chains";
+
+type ScaffoldConfig = {
+  targetNetwork: chain.Chain;
+  pollingInterval: number;
+  alchemyApiKey: string;
+};
+
+const scaffoldConfig: ScaffoldConfig = {
+  // The network where your DApp lives in
+  targetNetwork: chain.hardhat,
+
+  // The interval at which your front-end polls the RPC servers for new data
+  // it has no effect on the local network
+  pollingInterval: 30000,
+
+  // This is ours Alchemy's default API key.
+  // You can get your own at https://dashboard.alchemyapi.io
+  alchemyApiKey: "oKxs-03sij-U_N0iOlrSsZFr29-IqbuF",
+} as const;
+
+export default scaffoldConfig;

--- a/packages/nextjs/services/web3/wagmi-burner/burnerWalletConfig.ts
+++ b/packages/nextjs/services/web3/wagmi-burner/burnerWalletConfig.ts
@@ -1,4 +1,6 @@
 import { Chain, Wallet } from "@rainbow-me/rainbowkit";
+import { hardhat } from "wagmi/chains";
+import scaffoldConfig from "~~/scaffold.config";
 import {
   BurnerConnector,
   burnerWalletId,
@@ -21,7 +23,7 @@ export const burnerWalletConfig = ({ chains }: BurnerWalletOptions): Wallet => (
   iconUrl: "https://avatars.githubusercontent.com/u/56928858?s=200&v=4",
   iconBackground: "#0c2f78",
   //todo add conditions to hide burner wallet
-  hidden: () => process.env.NEXT_PUBLIC_NETWORK !== "hardhat",
+  hidden: () => scaffoldConfig.targetNetwork.id !== hardhat.id,
   createConnector: () => {
     const connector = new BurnerConnector({ chains, options: { defaultChainId: defaultBurnerChainId } });
 

--- a/packages/nextjs/services/web3/wagmiConnectors.tsx
+++ b/packages/nextjs/services/web3/wagmiConnectors.tsx
@@ -11,6 +11,7 @@ import { configureChains } from "wagmi";
 import * as chains from "wagmi/chains";
 import { alchemyProvider } from "wagmi/providers/alchemy";
 import { publicProvider } from "wagmi/providers/public";
+import scaffoldConfig from "~~/scaffold.config";
 import { burnerWalletConfig } from "~~/services/web3/wagmi-burner/burnerWalletConfig";
 import { getTargetNetwork } from "~~/utils/scaffold-eth";
 
@@ -25,10 +26,7 @@ export const appChains = configureChains(
   enabledChains,
   [
     alchemyProvider({
-      // ToDo. Move to .env || scaffold config
-      // This is ours Alchemy's default API key.
-      // You can get your own at https://dashboard.alchemyapi.io
-      apiKey: "oKxs-03sij-U_N0iOlrSsZFr29-IqbuF",
+      apiKey: scaffoldConfig.alchemyApiKey,
       priority: 0,
     }),
     publicProvider({ priority: 1 }),
@@ -36,11 +34,9 @@ export const appChains = configureChains(
   {
     stallTimeout: 3_000,
     // Sets pollingInterval if using chain's other than local hardhat chain
-    ...(process.env.NEXT_PUBLIC_NETWORK !== "hardhat"
+    ...(scaffoldConfig.targetNetwork.id !== chains.hardhat.id
       ? {
-          pollingInterval: process.env.NEXT_PUBLIC_RPC_POLLING_INTERVAL
-            ? parseInt(process.env.NEXT_PUBLIC_RPC_POLLING_INTERVAL)
-            : 30_000,
+          pollingInterval: scaffoldConfig.pollingInterval,
         }
       : {}),
   },
@@ -53,10 +49,7 @@ export const burnerChains = configureChains(
   [chains.hardhat],
   [
     alchemyProvider({
-      // ToDo. Move to .env || scaffold config
-      // This is ours Alchemy's default API key.
-      // You can get your own at https://dashboard.alchemyapi.io
-      apiKey: "oKxs-03sij-U_N0iOlrSsZFr29-IqbuF",
+      apiKey: scaffoldConfig.alchemyApiKey,
     }),
     publicProvider(),
   ],

--- a/packages/nextjs/services/web3/wagmiConnectors.tsx
+++ b/packages/nextjs/services/web3/wagmiConnectors.tsx
@@ -14,11 +14,10 @@ import { publicProvider } from "wagmi/providers/public";
 import scaffoldConfig from "~~/scaffold.config";
 import { burnerWalletConfig } from "~~/services/web3/wagmi-burner/burnerWalletConfig";
 
+const configuredNetwork = scaffoldConfig.targetNetwork;
+
 // We always want to have mainnet enabled (ENS resolution, ETH price, etc). But only once.
-const enabledChains =
-  scaffoldConfig.targetNetwork.id === 1
-    ? [scaffoldConfig.targetNetwork]
-    : [scaffoldConfig.targetNetwork, chains.mainnet];
+const enabledChains = configuredNetwork.id === 1 ? [configuredNetwork] : [configuredNetwork, chains.mainnet];
 
 /**
  * Chains for the app
@@ -35,7 +34,7 @@ export const appChains = configureChains(
   {
     stallTimeout: 3_000,
     // Sets pollingInterval if using chain's other than local hardhat chain
-    ...(scaffoldConfig.targetNetwork.id !== chains.hardhat.id
+    ...(configuredNetwork.id !== chains.hardhat.id
       ? {
           pollingInterval: scaffoldConfig.pollingInterval,
         }

--- a/packages/nextjs/services/web3/wagmiConnectors.tsx
+++ b/packages/nextjs/services/web3/wagmiConnectors.tsx
@@ -13,11 +13,12 @@ import { alchemyProvider } from "wagmi/providers/alchemy";
 import { publicProvider } from "wagmi/providers/public";
 import scaffoldConfig from "~~/scaffold.config";
 import { burnerWalletConfig } from "~~/services/web3/wagmi-burner/burnerWalletConfig";
-import { getTargetNetwork } from "~~/utils/scaffold-eth";
 
-const configuredChain = getTargetNetwork();
 // We always want to have mainnet enabled (ENS resolution, ETH price, etc). But only once.
-const enabledChains = configuredChain.id === 1 ? [configuredChain] : [configuredChain, chains.mainnet];
+const enabledChains =
+  scaffoldConfig.targetNetwork.id === 1
+    ? [scaffoldConfig.targetNetwork]
+    : [scaffoldConfig.targetNetwork, chains.mainnet];
 
 /**
  * Chains for the app

--- a/packages/nextjs/tsconfig.json
+++ b/packages/nextjs/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "baseUrl": "./",
     "target": "es5",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,

--- a/packages/nextjs/tsconfig.json
+++ b/packages/nextjs/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "baseUrl": "./",
     "target": "es5",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,

--- a/packages/nextjs/utils/scaffold-eth/networks.ts
+++ b/packages/nextjs/utils/scaffold-eth/networks.ts
@@ -55,7 +55,6 @@ export const NETWORKS_EXTRA_DATA: Record<string, TChainAttributes> = {
  * @dev returns empty string if the network is localChain
  */
 export function getBlockExplorerTxLink(network: Network, txnHash: string) {
-  let blockExplorerTxURL = "";
   const { chainId } = network;
 
   const chainNames = Object.keys(chains);
@@ -70,11 +69,8 @@ export function getBlockExplorerTxLink(network: Network, txnHash: string) {
   }
 
   const targetChain = targetChainArr[0] as keyof typeof chains;
-  // @ts-expect-error : ignoring error since `blockExplorers` key may or may not be present and we are already checking in ternary
-  blockExplorerTxURL = chains[targetChain]?.blockExplorers?.default?.url
-    ? // @ts-expect-error
-      chains[targetChain].blockExplorers.default.url
-    : "";
+  // @ts-expect-error : ignoring error since `blockExplorers` key may or may not be present on some chains
+  const blockExplorerTxURL = chains[targetChain]?.blockExplorers?.default?.url;
 
   if (!blockExplorerTxURL) {
     return "";

--- a/packages/nextjs/utils/scaffold-eth/networks.ts
+++ b/packages/nextjs/utils/scaffold-eth/networks.ts
@@ -1,6 +1,5 @@
 import { Network } from "@ethersproject/networks";
 import * as chains from "wagmi/chains";
-import scaffoldConfig from "~~/scaffold.config";
 
 export type TChainAttributes = {
   // color | [lightThemeColor, darkThemeColor]
@@ -83,18 +82,3 @@ export function getBlockExplorerTxLink(network: Network, txnHash: string) {
 
   return `${blockExplorerTxURL}/tx/${txnHash}`;
 }
-
-/**
- * Get the wagmi's Chain target network configured in the app.
- */
-export const getTargetNetwork = () => {
-  const network = scaffoldConfig.targetNetwork;
-
-  if (!network) {
-    // If error defaults to hardhat local network
-    console.error("Network name is not set, misspelled or unsupported network used in .env.*");
-    return chains.hardhat;
-  }
-
-  return network;
-};

--- a/packages/nextjs/utils/scaffold-eth/networks.ts
+++ b/packages/nextjs/utils/scaffold-eth/networks.ts
@@ -1,5 +1,6 @@
 import { Network } from "@ethersproject/networks";
 import * as chains from "wagmi/chains";
+import scaffoldConfig from "~~/scaffold.config";
 
 export type TChainAttributes = {
   // color | [lightThemeColor, darkThemeColor]
@@ -54,40 +55,46 @@ export const NETWORKS_EXTRA_DATA: Record<string, TChainAttributes> = {
  * @param txnHash
  * @dev returns empty string if the network is localChain
  */
-export const getBlockExplorerTxLink = (network: Network, txnHash: string) => {
-  const { name, chainId } = network;
+export function getBlockExplorerTxLink(network: Network, txnHash: string) {
+  let blockExplorerTxURL = "";
+  const { chainId } = network;
 
-  if (chainId === 31337 || chainId === 1337) {
-    // If its localChain then return empty sting
+  const chainNames = Object.keys(chains);
+
+  const targetChainArr = chainNames.filter(chainName => {
+    const wagmiChain = chains[chainName as keyof typeof chains];
+    return wagmiChain.id === chainId;
+  });
+
+  if (targetChainArr.length === 0) {
     return "";
   }
 
-  let blockExplorerNetwork = "";
-  if (name && chainId > 1) {
-    blockExplorerNetwork = name + ".";
+  const targetChain = targetChainArr[0] as keyof typeof chains;
+  // @ts-expect-error : ignoring error since `blockExplorers` key may or may not be present and we are already checking in ternary
+  blockExplorerTxURL = chains[targetChain]?.blockExplorers?.default?.url
+    ? // @ts-expect-error
+      chains[targetChain].blockExplorers.default.url
+    : "";
+
+  if (!blockExplorerTxURL) {
+    return "";
   }
 
-  let blockExplorerBaseTxUrl = "https://" + blockExplorerNetwork + "etherscan.io/tx/";
-  if (chainId === 100) {
-    blockExplorerBaseTxUrl = "https://blockscout.com/poa/xdai/tx/";
-  }
-
-  const blockExplorerTxURL = blockExplorerBaseTxUrl + txnHash;
-
-  return blockExplorerTxURL;
-};
+  return `${blockExplorerTxURL}/tx/${txnHash}`;
+}
 
 /**
  * Get the wagmi's Chain target network configured in the app.
  */
 export const getTargetNetwork = () => {
-  const network = process.env.NEXT_PUBLIC_NETWORK as keyof typeof chains;
+  const network = scaffoldConfig.targetNetwork;
 
-  if (!network || !chains[network]) {
+  if (!network) {
     // If error defaults to hardhat local network
     console.error("Network name is not set, misspelled or unsupported network used in .env.*");
     return chains.hardhat;
   }
 
-  return chains[network];
+  return network;
 };


### PR DESCRIPTION
### Description 
Added a  `scaffold.config.ts` in frontend instead for now as discussed in https://github.com/scaffold-eth/se-2/pull/231. 

Updated `network.ts` now it uses block explores links from `targetNetowork` and now you get transaction link for different blockexplores previously it used only show for etherscan and dai.... its the same as  https://github.com/scaffold-eth/se-2/pull/231#discussion_r1132625398

would love to make it more robust and inline in different PR 🙌

### Flow : 
1. `targetNetwork` from `scaffold.config.ts` is single source of truth now for frontend
2. Removed .env.* and added them inside `scaffold.config.ts`

