### PR TITLE
Fix: Infer types literal for scaffold.config

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ This command deploys a test smart contract to the local network. The contract is
 ```
 yarn start
 ```
-Visit your app on: `http://localhost:3000`. You can interact with your smart contract using the contract component or the example ui in the frontend.
+Visit your app on: `http://localhost:3000`. You can interact with your smart contract using the contract component or the example ui in the frontend. You can tweak the app config in `packages/nextjs/scaffold.config.ts`.
 
 Run smart contract test with `yarn hardhat:test`
 
@@ -116,7 +116,7 @@ Run `yarn vercel` and follow the steps to deploy to Vercel. Once you log in (ema
 
 If you want to redeploy to the same production URL you can run `yarn vercel --prod`. If you omit the `--prod` flag it will deploy it to a preview/test URL.
 
-**Make sure your `.env.production` file has the values you need.**
+**Make sure your `packages/nextjs/scaffold.config.ts` file has the values you need.**
 
 **Hint**: We recommend connecting the project GitHub repo to Vercel so you the gets automatically deployed when pushing to `main`
 

--- a/packages/hardhat/package.json
+++ b/packages/hardhat/package.json
@@ -37,7 +37,7 @@
     "hardhat": "^2.11.2",
     "hardhat-deploy": "^0.11.25",
     "hardhat-gas-reporter": "^1.0.9",
-    "prettier": "2.7.1",
+    "prettier": "^2.8.4",
     "solidity-coverage": "^0.8.2",
     "ts-node": "^10.9.1",
     "typechain": "^8.1.0",

--- a/packages/nextjs/components/Footer.tsx
+++ b/packages/nextjs/components/Footer.tsx
@@ -23,7 +23,7 @@ export const Footer = () => {
                 <span>{ethPrice}</span>
               </div>
             )}
-            {Number(scaffoldConfig.targetNetwork.id) === hardhat.id && <Faucet />}
+            {(scaffoldConfig.targetNetwork.id as number) === hardhat.id && <Faucet />}
           </div>
           <SwitchTheme className="pointer-events-auto" />
         </div>

--- a/packages/nextjs/components/Footer.tsx
+++ b/packages/nextjs/components/Footer.tsx
@@ -23,7 +23,7 @@ export const Footer = () => {
                 <span>{ethPrice}</span>
               </div>
             )}
-            {scaffoldConfig.targetNetwork.id === hardhat.id && <Faucet />}
+            {Number(scaffoldConfig.targetNetwork.id) === hardhat.id && <Faucet />}
           </div>
           <SwitchTheme className="pointer-events-auto" />
         </div>

--- a/packages/nextjs/components/Footer.tsx
+++ b/packages/nextjs/components/Footer.tsx
@@ -3,14 +3,15 @@ import { CurrencyDollarIcon } from "@heroicons/react/24/outline";
 import { HeartIcon } from "@heroicons/react/24/outline";
 import { SwitchTheme } from "~~/components/SwitchTheme";
 import { Faucet } from "~~/components/scaffold-eth";
-import scaffoldConfig from "~~/scaffold.config";
 import { useAppStore } from "~~/services/store/store";
+import { getTargetNetwork } from "~~/utils/scaffold-eth";
 
 /**
  * Site footer
  */
 export const Footer = () => {
   const ethPrice = useAppStore(state => state.ethPrice);
+  const configuredNetwork = getTargetNetwork();
 
   return (
     <div className="min-h-0 p-5 mb-11 lg:mb-0">
@@ -23,7 +24,7 @@ export const Footer = () => {
                 <span>{ethPrice}</span>
               </div>
             )}
-            {(scaffoldConfig.targetNetwork.id as number) === hardhat.id && <Faucet />}
+            {configuredNetwork.id === hardhat.id && <Faucet />}
           </div>
           <SwitchTheme className="pointer-events-auto" />
         </div>

--- a/packages/nextjs/components/Footer.tsx
+++ b/packages/nextjs/components/Footer.tsx
@@ -11,7 +11,6 @@ import { getTargetNetwork } from "~~/utils/scaffold-eth";
  */
 export const Footer = () => {
   const ethPrice = useAppStore(state => state.ethPrice);
-  const configuredNetwork = getTargetNetwork();
 
   return (
     <div className="min-h-0 p-5 mb-11 lg:mb-0">
@@ -24,7 +23,7 @@ export const Footer = () => {
                 <span>{ethPrice}</span>
               </div>
             )}
-            {configuredNetwork.id === hardhat.id && <Faucet />}
+            {getTargetNetwork().id === hardhat.id && <Faucet />}
           </div>
           <SwitchTheme className="pointer-events-auto" />
         </div>

--- a/packages/nextjs/components/scaffold-eth/Contract/ContractUI.tsx
+++ b/packages/nextjs/components/scaffold-eth/Contract/ContractUI.tsx
@@ -11,7 +11,7 @@ import {
   getContractWriteMethods,
 } from "~~/components/scaffold-eth";
 import { useDeployedContractInfo, useNetworkColor } from "~~/hooks/scaffold-eth";
-import scaffoldConfig from "~~/scaffold.config";
+import { getTargetNetwork } from "~~/utils/scaffold-eth";
 
 type TContractUIProps = {
   contractName: string;
@@ -24,7 +24,7 @@ type TContractUIProps = {
 export const ContractUI = ({ contractName, className = "" }: TContractUIProps) => {
   const provider = useProvider();
   const [refreshDisplayVariables, setRefreshDisplayVariables] = useState(false);
-  const configuredNetwork = scaffoldConfig.targetNetwork;
+  const configuredNetwork = getTargetNetwork();
 
   let contractAddress = "";
   let contractABI = [];

--- a/packages/nextjs/components/scaffold-eth/Contract/DisplayVariable.tsx
+++ b/packages/nextjs/components/scaffold-eth/Contract/DisplayVariable.tsx
@@ -4,8 +4,7 @@ import { useContractRead } from "wagmi";
 import { ArrowPathIcon } from "@heroicons/react/24/outline";
 import { displayTxResult } from "~~/components/scaffold-eth";
 import { useAnimationConfig } from "~~/hooks/scaffold-eth";
-import scaffoldConfig from "~~/scaffold.config";
-import { notification } from "~~/utils/scaffold-eth";
+import { getTargetNetwork, notification } from "~~/utils/scaffold-eth";
 
 type TDisplayVariableProps = {
   functionFragment: FunctionFragment;
@@ -23,7 +22,7 @@ export const DisplayVariable = ({
     isFetching,
     refetch,
   } = useContractRead({
-    chainId: scaffoldConfig.targetNetwork.id,
+    chainId: getTargetNetwork().id,
     address: contractAddress,
     abi: [functionFragment],
     functionName: functionFragment.name,

--- a/packages/nextjs/components/scaffold-eth/Contract/ReadOnlyFunctionForm.tsx
+++ b/packages/nextjs/components/scaffold-eth/Contract/ReadOnlyFunctionForm.tsx
@@ -7,8 +7,7 @@ import {
   getFunctionInputKey,
   getParsedContractFunctionArgs,
 } from "~~/components/scaffold-eth";
-import scaffoldConfig from "~~/scaffold.config";
-import { notification } from "~~/utils/scaffold-eth";
+import { getTargetNetwork, notification } from "~~/utils/scaffold-eth";
 
 const getInitialFormState = (functionFragment: FunctionFragment) => {
   const initialForm: Record<string, any> = {};
@@ -29,7 +28,7 @@ export const ReadOnlyFunctionForm = ({ functionFragment, contractAddress }: TRea
   const [result, setResult] = useState<unknown>();
 
   const { isFetching, refetch } = useContractRead({
-    chainId: scaffoldConfig.targetNetwork.id,
+    chainId: getTargetNetwork().id,
     address: contractAddress,
     abi: [functionFragment],
     functionName: functionFragment.name,

--- a/packages/nextjs/components/scaffold-eth/Contract/WriteOnlyFunctionForm.tsx
+++ b/packages/nextjs/components/scaffold-eth/Contract/WriteOnlyFunctionForm.tsx
@@ -12,8 +12,7 @@ import {
   getParsedEthersError,
 } from "~~/components/scaffold-eth";
 import { useTransactor } from "~~/hooks/scaffold-eth";
-import scaffoldConfig from "~~/scaffold.config";
-import { notification, parseTxnValue } from "~~/utils/scaffold-eth";
+import { getTargetNetwork, notification, parseTxnValue } from "~~/utils/scaffold-eth";
 
 // TODO set sensible initial state values to avoid error on first render, also put it in utilsContract
 const getInitialFormState = (functionFragment: FunctionFragment) => {
@@ -40,7 +39,7 @@ export const WriteOnlyFunctionForm = ({
   const [txValue, setTxValue] = useState<string | BigNumber>("");
   const { chain } = useNetwork();
   const writeTxn = useTransactor();
-  const writeDisabled = !chain || chain?.id !== scaffoldConfig.targetNetwork.id;
+  const writeDisabled = !chain || chain?.id !== getTargetNetwork().id;
 
   // We are omitting usePrepareContractWrite here to avoid unnecessary RPC calls and wrong gas estimations.
   // See:

--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton.tsx
@@ -2,7 +2,7 @@ import { ConnectButton } from "@rainbow-me/rainbowkit";
 import { ChevronDownIcon } from "@heroicons/react/24/solid";
 import { Balance, BlockieAvatar } from "~~/components/scaffold-eth";
 import { TAutoConnect, useAutoConnect, useNetworkColor } from "~~/hooks/scaffold-eth";
-import scaffoldConfig from "~~/scaffold.config";
+import { getTargetNetwork } from "~~/utils/scaffold-eth";
 
 // todo: move this later scaffold config.  See TAutoConnect for comments on each prop
 const tempAutoConnectConfig: TAutoConnect = {
@@ -17,7 +17,7 @@ export const RainbowKitCustomConnectButton = () => {
   useAutoConnect(tempAutoConnectConfig);
 
   const networkColor = useNetworkColor();
-  const configuredNetwork = scaffoldConfig.targetNetwork;
+  const configuredNetwork = getTargetNetwork();
 
   return (
     <ConnectButton.Custom>

--- a/packages/nextjs/hooks/scaffold-eth/useAccountBalance.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useAccountBalance.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { useBalance } from "wagmi";
-import scaffoldConfig from "~~/scaffold.config";
 import { useAppStore } from "~~/services/store/store";
+import { getTargetNetwork } from "~~/utils/scaffold-eth";
 
 export function useAccountBalance(address?: string) {
   const [isEthBalance, setIsEthBalance] = useState(true);
@@ -15,7 +15,7 @@ export function useAccountBalance(address?: string) {
   } = useBalance({
     address,
     watch: true,
-    chainId: scaffoldConfig.targetNetwork.id,
+    chainId: getTargetNetwork().id,
   });
 
   const onToggleBalance = useCallback(() => {

--- a/packages/nextjs/hooks/scaffold-eth/useAutoConnect.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useAutoConnect.ts
@@ -33,7 +33,7 @@ const getInitialConnector = (
   connectors: Connector<any, any, any>[],
 ): { connector: Connector | undefined; chainId?: number } | undefined => {
   const allowBurner = config.enableBurnerWallet;
-  const isLocalChainSelected = Number(scaffoldConfig.targetNetwork.id) === hardhat.id;
+  const isLocalChainSelected = (scaffoldConfig.targetNetwork.id as number) === hardhat.id;
 
   if (!previousWalletId) {
     // The user was not connected to a wallet

--- a/packages/nextjs/hooks/scaffold-eth/useAutoConnect.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useAutoConnect.ts
@@ -33,7 +33,7 @@ const getInitialConnector = (
   connectors: Connector<any, any, any>[],
 ): { connector: Connector | undefined; chainId?: number } | undefined => {
   const allowBurner = config.enableBurnerWallet;
-  const isLocalChainSelected = scaffoldConfig.targetNetwork.id === hardhat.id;
+  const isLocalChainSelected = Number(scaffoldConfig.targetNetwork.id) === hardhat.id;
 
   if (!previousWalletId) {
     // The user was not connected to a wallet

--- a/packages/nextjs/hooks/scaffold-eth/useAutoConnect.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useAutoConnect.ts
@@ -33,8 +33,7 @@ const getInitialConnector = (
   connectors: Connector<any, any, any>[],
 ): { connector: Connector | undefined; chainId?: number } | undefined => {
   const allowBurner = config.enableBurnerWallet;
-  const configuredNetwork = getTargetNetwork();
-  const isLocalChainSelected = configuredNetwork.id === hardhat.id;
+  const isLocalChainSelected = getTargetNetwork().id === hardhat.id;
 
   if (!previousWalletId) {
     // The user was not connected to a wallet

--- a/packages/nextjs/hooks/scaffold-eth/useAutoConnect.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useAutoConnect.ts
@@ -2,8 +2,8 @@ import { useEffect } from "react";
 import { useEffectOnce, useLocalStorage } from "usehooks-ts";
 import { Connector, useAccount, useConnect } from "wagmi";
 import { hardhat } from "wagmi/chains";
-import scaffoldConfig from "~~/scaffold.config";
 import { burnerWalletId, defaultBurnerChainId } from "~~/services/web3/wagmi-burner/BurnerConnector";
+import { getTargetNetwork } from "~~/utils/scaffold-eth";
 
 export type TAutoConnect = {
   /**
@@ -33,7 +33,8 @@ const getInitialConnector = (
   connectors: Connector<any, any, any>[],
 ): { connector: Connector | undefined; chainId?: number } | undefined => {
   const allowBurner = config.enableBurnerWallet;
-  const isLocalChainSelected = (scaffoldConfig.targetNetwork.id as number) === hardhat.id;
+  const configuredNetwork = getTargetNetwork();
+  const isLocalChainSelected = configuredNetwork.id === hardhat.id;
 
   if (!previousWalletId) {
     // The user was not connected to a wallet

--- a/packages/nextjs/hooks/scaffold-eth/useDeployedContractInfo.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useDeployedContractInfo.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { useProvider } from "wagmi";
-import scaffoldConfig from "~~/scaffold.config";
+import { getTargetNetwork } from "~~/utils/scaffold-eth";
 
 type GeneratedContractType = {
   address: string;
@@ -15,7 +15,7 @@ type GeneratedContractType = {
 export const useDeployedContractInfo = (contractName: string | undefined | null) => {
   const [deployedContractData, setDeployedContractData] = useState<undefined | GeneratedContractType>(undefined);
   const [isLoading, setIsLoading] = useState(true);
-  const configuredNetwork = scaffoldConfig.targetNetwork;
+  const configuredNetwork = getTargetNetwork();
 
   const provider = useProvider({ chainId: configuredNetwork.id });
 

--- a/packages/nextjs/hooks/scaffold-eth/useDeployedContractNames.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useDeployedContractNames.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import scaffoldConfig from "~~/scaffold.config";
+import { getTargetNetwork } from "~~/utils/scaffold-eth";
 
 /**
  * @dev use this hook to get the list of contracts deployed by `yarn deploy`.
@@ -12,7 +12,7 @@ export const useDeployedContractNames = () => {
     try {
       // eslint-disable-next-line @typescript-eslint/no-var-requires
       const contracts = require("~~/generated/hardhat_contracts.json");
-      const contractsAtChain = contracts[`${scaffoldConfig.targetNetwork.id}` as keyof typeof contracts];
+      const contractsAtChain = contracts[`${getTargetNetwork().id}` as keyof typeof contracts];
       const contractsData = contractsAtChain?.[0]?.contracts;
       const contractNames = contractsData ? Object.keys(contractsData) : [];
 

--- a/packages/nextjs/hooks/scaffold-eth/useNetworkColor.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useNetworkColor.ts
@@ -1,6 +1,5 @@
 import { useDarkMode } from "usehooks-ts";
-import scaffoldConfig from "~~/scaffold.config";
-import { NETWORKS_EXTRA_DATA } from "~~/utils/scaffold-eth";
+import { getTargetNetwork } from "~~/utils/scaffold-eth";
 
 const DEFAULT_NETWORK_COLOR: [string, string] = ["#666666", "#bbbbbb"];
 
@@ -9,11 +8,8 @@ const DEFAULT_NETWORK_COLOR: [string, string] = ["#666666", "#bbbbbb"];
  */
 export const useNetworkColor = () => {
   const { isDarkMode } = useDarkMode();
-  const networkDetails = NETWORKS_EXTRA_DATA[scaffoldConfig.targetNetwork.id] ?? { color: DEFAULT_NETWORK_COLOR };
+  const configuredNetwork = getTargetNetwork();
+  const colorConfig = configuredNetwork.color ?? DEFAULT_NETWORK_COLOR;
 
-  return Array.isArray(networkDetails.color)
-    ? isDarkMode
-      ? networkDetails.color[1]
-      : networkDetails.color[0]
-    : networkDetails.color;
+  return Array.isArray(colorConfig) ? (isDarkMode ? colorConfig[1] : colorConfig[0]) : colorConfig;
 };

--- a/packages/nextjs/hooks/scaffold-eth/useNetworkColor.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useNetworkColor.ts
@@ -8,8 +8,7 @@ const DEFAULT_NETWORK_COLOR: [string, string] = ["#666666", "#bbbbbb"];
  */
 export const useNetworkColor = () => {
   const { isDarkMode } = useDarkMode();
-  const configuredNetwork = getTargetNetwork();
-  const colorConfig = configuredNetwork.color ?? DEFAULT_NETWORK_COLOR;
+  const colorConfig = getTargetNetwork().color ?? DEFAULT_NETWORK_COLOR;
 
   return Array.isArray(colorConfig) ? (isDarkMode ? colorConfig[1] : colorConfig[0]) : colorConfig;
 };

--- a/packages/nextjs/hooks/scaffold-eth/useScaffoldContractRead.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useScaffoldContractRead.ts
@@ -1,7 +1,7 @@
 import type { Abi } from "abitype";
 import { useContractRead } from "wagmi";
 import { useDeployedContractInfo } from "~~/hooks/scaffold-eth";
-import scaffoldConfig from "~~/scaffold.config";
+import { getTargetNetwork } from "~~/utils/scaffold-eth";
 
 /**
  * @dev wrapper for wagmi's useContractRead hook which loads in deployed contract contract abi, address automatically
@@ -19,7 +19,7 @@ export const useScaffoldContractRead = <TReturn = any>(
   const { data: deployedContractData } = useDeployedContractInfo(contractName);
 
   return useContractRead({
-    chainId: scaffoldConfig.targetNetwork.id,
+    chainId: getTargetNetwork().id,
     functionName,
     address: deployedContractData?.address,
     abi: deployedContractData?.abi as Abi,

--- a/packages/nextjs/hooks/scaffold-eth/useScaffoldContractWrite.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useScaffoldContractWrite.ts
@@ -3,8 +3,7 @@ import { utils } from "ethers";
 import { useContractWrite, useNetwork } from "wagmi";
 import { getParsedEthersError } from "~~/components/scaffold-eth";
 import { useDeployedContractInfo, useTransactor } from "~~/hooks/scaffold-eth";
-import scaffoldConfig from "~~/scaffold.config";
-import { notification } from "~~/utils/scaffold-eth";
+import { getTargetNetwork, notification } from "~~/utils/scaffold-eth";
 
 /**
  * @dev wrapper for wagmi's useContractWrite hook(with config prepared by usePrepareContractWrite hook) which loads in deployed contract abi and address automatically
@@ -18,7 +17,7 @@ export const useScaffoldContractWrite = (contractName: string, functionName: str
   const { chain } = useNetwork();
   const writeTx = useTransactor();
   const [isMining, setIsMining] = useState(false);
-  const configuredNetwork = scaffoldConfig.targetNetwork;
+  const configuredNetwork = getTargetNetwork();
 
   const wagmiContractWrite = useContractWrite({
     mode: "recklesslyUnprepared",

--- a/packages/nextjs/hooks/scaffold-eth/useScaffoldEventSubscriber.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useScaffoldEventSubscriber.ts
@@ -1,6 +1,6 @@
 import { useContractEvent } from "wagmi";
 import { useDeployedContractInfo } from "~~/hooks/scaffold-eth";
-import scaffoldConfig from "~~/scaffold.config";
+import { getTargetNetwork } from "~~/utils/scaffold-eth";
 
 /**
  * @dev wrapper for wagmi's useContractEvent
@@ -20,7 +20,7 @@ export const useScaffoldEventSubscriber = (
   return useContractEvent({
     address: deployedContractData?.address,
     abi: deployedContractData?.abi,
-    chainId: scaffoldConfig.targetNetwork.id,
+    chainId: getTargetNetwork().id,
     listener: callbackListener,
     eventName,
     once,

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -47,7 +47,7 @@
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-prettier": "^4.2.1",
     "postcss": "^8.4.16",
-    "prettier": "^2.7.1",
+    "prettier": "^2.8.4",
     "tailwindcss": "^3.1.8",
     "typescript": "^4.9.5",
     "vercel": "^28.15.1"

--- a/packages/nextjs/scaffold.config.ts
+++ b/packages/nextjs/scaffold.config.ts
@@ -6,9 +6,9 @@ type ScaffoldConfig = {
   alchemyApiKey: string;
 };
 
-const scaffoldConfig: ScaffoldConfig = {
+const scaffoldConfig = {
   // The network where your DApp lives in
-  targetNetwork: chains.hardhat,
+  targetNetwork: chains.mainnet,
 
   // The interval at which your front-end polls the RPC servers for new data
   // it has no effect on the local network
@@ -19,6 +19,6 @@ const scaffoldConfig: ScaffoldConfig = {
   // It's recommended to store it in an env variable:
   // .env.local for local testing, and in the Vercel/system env config for live apps.
   alchemyApiKey: process.env.NEXT_PUBLIC_ALCHEMY_API_KEY || "oKxs-03sij-U_N0iOlrSsZFr29-IqbuF",
-} as const;
+} satisfies ScaffoldConfig;
 
 export default scaffoldConfig;

--- a/packages/nextjs/scaffold.config.ts
+++ b/packages/nextjs/scaffold.config.ts
@@ -8,7 +8,7 @@ type ScaffoldConfig = {
 
 const scaffoldConfig = {
   // The network where your DApp lives in
-  targetNetwork: chains.mainnet,
+  targetNetwork: chains.hardhat,
 
   // The interval at which your front-end polls the RPC servers for new data
   // it has no effect on the local network

--- a/packages/nextjs/services/web3/wagmi-burner/burnerWalletConfig.ts
+++ b/packages/nextjs/services/web3/wagmi-burner/burnerWalletConfig.ts
@@ -1,17 +1,18 @@
 import { Chain, Wallet } from "@rainbow-me/rainbowkit";
 import { hardhat } from "wagmi/chains";
-import scaffoldConfig from "~~/scaffold.config";
 import {
   BurnerConnector,
   burnerWalletId,
   burnerWalletName,
   defaultBurnerChainId,
 } from "~~/services/web3/wagmi-burner/BurnerConnector";
+import { getTargetNetwork } from "~~/utils/scaffold-eth";
 
 export interface BurnerWalletOptions {
   chains: Chain[];
 }
 
+const configuredNetwork = getTargetNetwork();
 /**
  * Wagmi config for burner wallet
  * @param param0
@@ -23,7 +24,7 @@ export const burnerWalletConfig = ({ chains }: BurnerWalletOptions): Wallet => (
   iconUrl: "https://avatars.githubusercontent.com/u/56928858?s=200&v=4",
   iconBackground: "#0c2f78",
   //todo add conditions to hide burner wallet
-  hidden: () => (scaffoldConfig.targetNetwork.id as number) !== hardhat.id,
+  hidden: () => configuredNetwork.id !== hardhat.id,
   createConnector: () => {
     const connector = new BurnerConnector({ chains, options: { defaultChainId: defaultBurnerChainId } });
 

--- a/packages/nextjs/services/web3/wagmi-burner/burnerWalletConfig.ts
+++ b/packages/nextjs/services/web3/wagmi-burner/burnerWalletConfig.ts
@@ -12,7 +12,6 @@ export interface BurnerWalletOptions {
   chains: Chain[];
 }
 
-const configuredNetwork = getTargetNetwork();
 /**
  * Wagmi config for burner wallet
  * @param param0
@@ -24,7 +23,7 @@ export const burnerWalletConfig = ({ chains }: BurnerWalletOptions): Wallet => (
   iconUrl: "https://avatars.githubusercontent.com/u/56928858?s=200&v=4",
   iconBackground: "#0c2f78",
   //todo add conditions to hide burner wallet
-  hidden: () => configuredNetwork.id !== hardhat.id,
+  hidden: () => getTargetNetwork().id !== hardhat.id,
   createConnector: () => {
     const connector = new BurnerConnector({ chains, options: { defaultChainId: defaultBurnerChainId } });
 

--- a/packages/nextjs/services/web3/wagmi-burner/burnerWalletConfig.ts
+++ b/packages/nextjs/services/web3/wagmi-burner/burnerWalletConfig.ts
@@ -23,7 +23,7 @@ export const burnerWalletConfig = ({ chains }: BurnerWalletOptions): Wallet => (
   iconUrl: "https://avatars.githubusercontent.com/u/56928858?s=200&v=4",
   iconBackground: "#0c2f78",
   //todo add conditions to hide burner wallet
-  hidden: () => scaffoldConfig.targetNetwork.id !== hardhat.id,
+  hidden: () => Number(scaffoldConfig.targetNetwork.id) !== hardhat.id,
   createConnector: () => {
     const connector = new BurnerConnector({ chains, options: { defaultChainId: defaultBurnerChainId } });
 

--- a/packages/nextjs/services/web3/wagmi-burner/burnerWalletConfig.ts
+++ b/packages/nextjs/services/web3/wagmi-burner/burnerWalletConfig.ts
@@ -23,7 +23,7 @@ export const burnerWalletConfig = ({ chains }: BurnerWalletOptions): Wallet => (
   iconUrl: "https://avatars.githubusercontent.com/u/56928858?s=200&v=4",
   iconBackground: "#0c2f78",
   //todo add conditions to hide burner wallet
-  hidden: () => Number(scaffoldConfig.targetNetwork.id) !== hardhat.id,
+  hidden: () => (scaffoldConfig.targetNetwork.id as number) !== hardhat.id,
   createConnector: () => {
     const connector = new BurnerConnector({ chains, options: { defaultChainId: defaultBurnerChainId } });
 

--- a/packages/nextjs/services/web3/wagmiConnectors.tsx
+++ b/packages/nextjs/services/web3/wagmiConnectors.tsx
@@ -17,7 +17,7 @@ import { burnerWalletConfig } from "~~/services/web3/wagmi-burner/burnerWalletCo
 const configuredNetwork = scaffoldConfig.targetNetwork;
 
 // We always want to have mainnet enabled (ENS resolution, ETH price, etc). But only once.
-const enabledChains = configuredNetwork.id === 1 ? [configuredNetwork] : [configuredNetwork, chains.mainnet];
+const enabledChains = Number(configuredNetwork.id) === 1 ? [configuredNetwork] : [configuredNetwork, chains.mainnet];
 
 /**
  * Chains for the app
@@ -34,7 +34,7 @@ export const appChains = configureChains(
   {
     stallTimeout: 3_000,
     // Sets pollingInterval if using chain's other than local hardhat chain
-    ...(configuredNetwork.id !== chains.hardhat.id
+    ...(Number(configuredNetwork.id) !== chains.hardhat.id
       ? {
           pollingInterval: scaffoldConfig.pollingInterval,
         }

--- a/packages/nextjs/services/web3/wagmiConnectors.tsx
+++ b/packages/nextjs/services/web3/wagmiConnectors.tsx
@@ -13,12 +13,12 @@ import { alchemyProvider } from "wagmi/providers/alchemy";
 import { publicProvider } from "wagmi/providers/public";
 import scaffoldConfig from "~~/scaffold.config";
 import { burnerWalletConfig } from "~~/services/web3/wagmi-burner/burnerWalletConfig";
+import { getTargetNetwork } from "~~/utils/scaffold-eth";
 
-const configuredNetwork = scaffoldConfig.targetNetwork;
+const configuredNetwork = getTargetNetwork();
 
 // We always want to have mainnet enabled (ENS resolution, ETH price, etc). But only once.
-const enabledChains =
-  (configuredNetwork.id as number) === 1 ? [configuredNetwork] : [configuredNetwork, chains.mainnet];
+const enabledChains = configuredNetwork.id === 1 ? [configuredNetwork] : [configuredNetwork, chains.mainnet];
 
 /**
  * Chains for the app
@@ -35,7 +35,7 @@ export const appChains = configureChains(
   {
     stallTimeout: 3_000,
     // Sets pollingInterval if using chain's other than local hardhat chain
-    ...((configuredNetwork.id as number) !== chains.hardhat.id
+    ...(configuredNetwork.id !== chains.hardhat.id
       ? {
           pollingInterval: scaffoldConfig.pollingInterval,
         }

--- a/packages/nextjs/services/web3/wagmiConnectors.tsx
+++ b/packages/nextjs/services/web3/wagmiConnectors.tsx
@@ -17,7 +17,8 @@ import { burnerWalletConfig } from "~~/services/web3/wagmi-burner/burnerWalletCo
 const configuredNetwork = scaffoldConfig.targetNetwork;
 
 // We always want to have mainnet enabled (ENS resolution, ETH price, etc). But only once.
-const enabledChains = Number(configuredNetwork.id) === 1 ? [configuredNetwork] : [configuredNetwork, chains.mainnet];
+const enabledChains =
+  (configuredNetwork.id as number) === 1 ? [configuredNetwork] : [configuredNetwork, chains.mainnet];
 
 /**
  * Chains for the app
@@ -34,7 +35,7 @@ export const appChains = configureChains(
   {
     stallTimeout: 3_000,
     // Sets pollingInterval if using chain's other than local hardhat chain
-    ...(Number(configuredNetwork.id) !== chains.hardhat.id
+    ...((configuredNetwork.id as number) !== chains.hardhat.id
       ? {
           pollingInterval: scaffoldConfig.pollingInterval,
         }

--- a/packages/nextjs/utils/scaffold-eth/networks.ts
+++ b/packages/nextjs/utils/scaffold-eth/networks.ts
@@ -81,7 +81,7 @@ export function getBlockExplorerTxLink(network: Network, txnHash: string) {
 }
 
 /**
- * @returns targetNetwork object consisting targetNetwork from scaffold.config and extra network meta data
+ * @returns targetNetwork object consisting targetNetwork from scaffold.config and extra network metadata
  */
 
 export function getTargetNetwork(): chains.Chain & Partial<TChainAttributes> {

--- a/packages/nextjs/utils/scaffold-eth/networks.ts
+++ b/packages/nextjs/utils/scaffold-eth/networks.ts
@@ -1,5 +1,6 @@
 import { Network } from "@ethersproject/networks";
 import * as chains from "wagmi/chains";
+import scaffoldConfig from "~~/scaffold.config";
 
 export type TChainAttributes = {
   // color | [lightThemeColor, darkThemeColor]
@@ -77,4 +78,17 @@ export function getBlockExplorerTxLink(network: Network, txnHash: string) {
   }
 
   return `${blockExplorerTxURL}/tx/${txnHash}`;
+}
+
+/**
+ * @returns targetNetwork object consisting targetNetwork from scaffold.config and extra network meta data
+ */
+
+export function getTargetNetwork(): chains.Chain & Partial<TChainAttributes> {
+  const configuredNetwork = scaffoldConfig.targetNetwork;
+
+  return {
+    ...configuredNetwork,
+    ...NETWORKS_EXTRA_DATA[configuredNetwork.id],
+  };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1797,7 +1797,7 @@ __metadata:
     hardhat: ^2.11.2
     hardhat-deploy: ^0.11.25
     hardhat-gas-reporter: ^1.0.9
-    prettier: 2.7.1
+    prettier: ^2.8.4
     qrcode: ^1.5.1
     solidity-coverage: ^0.8.2
     ts-node: ^10.9.1
@@ -1831,7 +1831,7 @@ __metadata:
     next: ^13.1.6
     nextjs-progressbar: ^0.0.16
     postcss: ^8.4.16
-    prettier: ^2.7.1
+    prettier: ^2.8.4
     react: ^18.2.0
     react-blockies: ^1.4.1
     react-copy-to-clipboard: ^5.1.0
@@ -10889,12 +10889,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:2.7.1, prettier@npm:^2.3.1, prettier@npm:^2.7.1":
+"prettier@npm:^2.3.1":
   version: 2.7.1
   resolution: "prettier@npm:2.7.1"
   bin:
     prettier: bin-prettier.js
   checksum: 55a4409182260866ab31284d929b3cb961e5fdb91fe0d2e099dac92eaecec890f36e524b4c19e6ceae839c99c6d7195817579cdffc8e2c80da0cb794463a748b
+  languageName: node
+  linkType: hard
+
+"prettier@npm:^2.8.4":
+  version: 2.8.4
+  resolution: "prettier@npm:2.8.4"
+  bin:
+    prettier: bin-prettier.js
+  checksum: c173064bf3df57b6d93d19aa98753b9b9dd7657212e33b41ada8e2e9f9884066bb9ca0b4005b89b3ab137efffdf8fbe0b462785aba20364798ff4303aadda57e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description : 
This is a small patch for #246, it seems that in that PR when we try to access `targetNetwork` types widening was happens 
![Screenshot 2023-03-20 at 12 16 01 AM](https://user-images.githubusercontent.com/80153681/226203141-b8200882-c989-46f2-bb43-01388ab6106a.jpg)

Now : 
![Screenshot 2023-03-20 at 12 17 01 AM](https://user-images.githubusercontent.com/80153681/226203158-1545ad81-f00a-4df6-a4fa-f81db482b42a.jpg)


Had to upgrade prettier since support typescript `satisfies` was added in 2.8 checkout -> https://prettier.io/blog/2022/11/23/2.8.0.html 