### PR TITLE
Fix hardhat deploy script

### DIFF
--- a/packages/hardhat/package.json
+++ b/packages/hardhat/package.json
@@ -5,7 +5,7 @@
     "account": "hardhat run scripts/listAccount.ts",
     "chain": "hardhat node --network hardhat --no-deploy",
     "compile": "hardhat compile",
-    "deploy": "hardhat deploy --export-all ../nextjs/generated/hardhat_contracts.json && yarn generateTsAbis",
+    "deploy": "hardhat deploy --export-all ../nextjs/generated/hardhat_contracts.json \"$@\" && yarn generateTsAbis",
     "fork": "MAINNET_FORKING_ENABLED=true hardhat node --network hardhat --no-deploy",
     "generate": "hardhat run scripts/generateAccount.ts",
     "generateTsAbis": "hardhat run scripts/generateTsAbis.ts",


### PR DESCRIPTION
Fixes #252 

Approach : 
Used the `$@` in deploy script, This will pass all the command line args `hardhat deploy`. 

Test : 
![Screenshot 2023-03-22 at 9 24 17 PM](https://user-images.githubusercontent.com/80153681/226963272-16c468cd-5199-4c92-88f0-4fe121ce4a60.jpg)

