### PR TITLE
refactor: small improvement for empty contracts

### DIFF
--- a/packages/nextjs/components/scaffold-eth/Faucet.tsx
+++ b/packages/nextjs/components/scaffold-eth/Faucet.tsx
@@ -28,7 +28,7 @@ export const Faucet = () => {
   useEffect(() => {
     const getFaucetAddress = async () => {
       try {
-        if (provider && Object.keys(contracts).length) {
+        if (provider && contracts) {
           const accounts = await provider.listAccounts();
           setFaucetAddress(accounts[FAUCET_ACCOUNT_INDEX]);
         }

--- a/packages/nextjs/hooks/scaffold-eth/useAutoConnect.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useAutoConnect.ts
@@ -65,7 +65,7 @@ export const useAutoConnect = (): void => {
   }, [accountState.isConnected, accountState.connector?.name]);
 
   useEffectOnce(() => {
-    if (!Object.keys(contracts).length) {
+    if (!contracts) {
       return;
     }
 

--- a/packages/nextjs/scripts/generateEmptyContractFile.mjs
+++ b/packages/nextjs/scripts/generateEmptyContractFile.mjs
@@ -11,7 +11,7 @@ const __dirname = path.dirname(new URL(import.meta.url).pathname);
 const nextJsDir = path.resolve(__dirname, "..");
 
 const contractsFilePath = path.join(nextJsDir, "generated", "hardhat_contracts.ts");
-const content = "export default {} as const;\n";
+const content = "const contracts = null;\nexport default contracts;\n";
 
 if (!fs.existsSync(contractsFilePath)) {
   // Create the 'generated' directory if it doesn't exist

--- a/packages/nextjs/utils/scaffold-eth/contract.ts
+++ b/packages/nextjs/utils/scaffold-eth/contract.ts
@@ -4,25 +4,22 @@ import { UseContractEventConfig, UseContractReadConfig, UseContractWriteConfig }
 import contractsData from "~~/generated/hardhat_contracts";
 import scaffoldConfig from "~~/scaffold.config";
 
-type ContractsData =
-  | Record<string, never>
-  | {
-      [key: number]: readonly {
-        name: string;
-        chainId: string;
-        contracts: {
-          [key: string]: {
-            address: string;
-            abi: Abi;
-          };
-        };
-      }[];
+export type GenericContractsDeclaration = {
+  [key: number]: readonly {
+    name: string;
+    chainId: string;
+    contracts: {
+      [key: string]: {
+        address: string;
+        abi: Abi;
+      };
     };
-export type GenericContractsDeclaration = Exclude<ContractsData, Record<string, never>>;
+  }[];
+};
 
-export const contracts = contractsData as GenericContractsDeclaration;
+export const contracts = contractsData as GenericContractsDeclaration | null;
 
-type IsContractsFileMissing<TYes, TNo> = typeof contractsData extends Record<string, never> ? TYes : TNo;
+type IsContractsFileMissing<TYes, TNo> = typeof contractsData extends null ? TYes : TNo;
 type ContractsDeclaration = IsContractsFileMissing<GenericContractsDeclaration, typeof contractsData>;
 
 export type Chain = keyof ContractsDeclaration;


### PR DESCRIPTION
@carletex I cleaned it up a little and the empty contracts is now `null`, that way we no longer need to check `Object.keys().length`, which is a bit cleaner.