### PR TITLE
use targetNetwork blockExplorer link for AddressComponent

### DIFF
--- a/packages/nextjs/components/scaffold-eth/Address.tsx
+++ b/packages/nextjs/components/scaffold-eth/Address.tsx
@@ -5,13 +5,10 @@ import Blockies from "react-blockies";
 import { CopyToClipboard } from "react-copy-to-clipboard";
 import { useEnsAvatar, useEnsName } from "wagmi";
 import { CheckCircleIcon, DocumentDuplicateIcon } from "@heroicons/react/24/outline";
-
-const blockExplorerLink = (address: string, blockExplorer?: string) =>
-  `${blockExplorer || "https://etherscan.io/"}address/${address}`;
+import { getBlockExplorerAddressLink, getTargetNetwork } from "~~/utils/scaffold-eth";
 
 type TAddressProps = {
   address?: string;
-  blockExplorer?: string;
   disableAddressLink?: boolean;
   format?: "short" | "long";
 };
@@ -19,7 +16,7 @@ type TAddressProps = {
 /**
  * Displays an address (or ENS) with a Blockie image and option to copy address.
  */
-export const Address = ({ address, blockExplorer, disableAddressLink, format }: TAddressProps) => {
+export const Address = ({ address, disableAddressLink, format }: TAddressProps) => {
   const [ens, setEns] = useState<string | null>();
   const [ensAvatar, setEnsAvatar] = useState<string | null>();
   const [addressCopied, setAddressCopied] = useState(false);
@@ -57,7 +54,7 @@ export const Address = ({ address, blockExplorer, disableAddressLink, format }: 
     return <span className="text-error">Wrong address</span>;
   }
 
-  const explorerLink = blockExplorerLink(address, blockExplorer);
+  const blockExplorerAddressLink = getBlockExplorerAddressLink(getTargetNetwork(), address);
   let displayAddress = address?.slice(0, 5) + "..." + address?.slice(-4);
 
   if (ens) {
@@ -80,7 +77,12 @@ export const Address = ({ address, blockExplorer, disableAddressLink, format }: 
       {disableAddressLink ? (
         <span className="ml-1.5 text-lg font-normal">{displayAddress}</span>
       ) : (
-        <a className="ml-1.5 text-lg font-normal" target="_blank" href={explorerLink} rel="noopener noreferrer">
+        <a
+          className="ml-1.5 text-lg font-normal"
+          target="_blank"
+          href={blockExplorerAddressLink}
+          rel="noopener noreferrer"
+        >
           {displayAddress}
         </a>
       )}

--- a/packages/nextjs/utils/scaffold-eth/networks.ts
+++ b/packages/nextjs/utils/scaffold-eth/networks.ts
@@ -81,6 +81,21 @@ export function getBlockExplorerTxLink(network: Network, txnHash: string) {
 }
 
 /**
+ * Gives the block explorer Address URL.
+ * @param network - wagmi chain object
+ * @param address
+ * @returns block explorer address URL and etherscan URL if block explorer URL is not present for wagmi network
+ */
+export function getBlockExplorerAddressLink(network: chains.Chain, address: string) {
+  const blockExplorerBaseURL = network.blockExplorers?.default?.url;
+  if (!blockExplorerBaseURL) {
+    return `https://etherscan.io/address/${address}`;
+  }
+
+  return `${blockExplorerBaseURL}/address/${address}`;
+}
+
+/**
  * @returns targetNetwork object consisting targetNetwork from scaffold.config and extra network metadata
  */
 


### PR DESCRIPTION
Fixes #265 

- Liked the approach mentioned by Carlos in https://github.com/scaffold-eth/se-2/issues/265#issue-1645509779 so used it. 

- Moved this function to `network.ts` below `getBlockExplorerTxLink` as `getBlockExplorerAddressLink`, don't know if it was worth it.....Should we move it back to the Address component?  Its seems little consistent in `network.ts`


Also was wondering if should we handle https://github.com/scaffold-eth/se-2/pull/231#discussion_r1132625398 in this PR itself? 

