### PR TITLE
Use prepareHook with useScaffoldContractWrite

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn lint-staged --verbose
+# yarn lint-staged --verbose

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-# yarn lint-staged --verbose
+yarn lint-staged --verbose

--- a/packages/hardhat/contracts/YourContract.sol
+++ b/packages/hardhat/contracts/YourContract.sol
@@ -1,8 +1,8 @@
-//SPDX-License-Identifier: MIT
+// /SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0 <0.9.0;
 
 // Useful for debugging. Remove when deploying to a live network.
-import "hardhat/console.sol";
+//import "hardhat/console.sol";
 // Use openzeppelin to inherit battle-tested implementations (ERC20, ERC721, etc)
 // import "@openzeppelin/contracts/access/Ownable.sol";
 
@@ -12,67 +12,56 @@ import "hardhat/console.sol";
  * @author BuidlGuidl
  */
 contract YourContract {
+  // State Variables
+  address public owner;
+  uint256 public checkedInNow;
+  mapping(address => bool) hasCheckedIn;
 
-    // State Variables
-    address public immutable owner;
-    string public greeting = "Building Unstoppable Apps!!!";
-    bool public premium = false;
-    uint256 public totalCounter = 0;
-    mapping(address => uint) public userGreetingCounter;
+  // Constructor: Called once on contract deployment
+  // Check packages/hardhat/deploy/00_deploy_your_contract.ts
+  constructor(address _owner) {
+    owner = _owner;
+  }
 
-    // Events: a way to emit log statements from smart contract that can be listened to by external parties
-    event GreetingChange(address greetingSetter, string newGreeting, bool premium, uint256 value);
+  // Modifier: used to define a set of rules that must be met before or after a function is executed
+  // Check the withdraw() function
+  modifier isOwner() {
+    // msg.sender: predefined variable that represents address of the account that called the current function
+    require(msg.sender == owner, "Not the Owner");
+    _;
+  }
 
-    // Constructor: Called once on contract deployment
-    // Check packages/hardhat/deploy/00_deploy_your_contract.ts
-    constructor(address _owner) {
-        owner = _owner;
-    }
+  function setNewOwner(address someAddress) public isOwner {
+    owner = someAddress;
+  }
 
-    // Modifier: used to define a set of rules that must be met before or after a function is executed
-    // Check the withdraw() function
-    modifier isOwner() {
-        // msg.sender: predefined variable that represents address of the account that called the current function
-        require(msg.sender == owner, "Not the Owner");
-        _;
-    }
+  function checkin() public payable {
+    require(!hasCheckedIn[msg.sender], "Already checked in");
+    require(msg.value == 0.001 ether, "Must pay 0.001 ether to check in");
+    hasCheckedIn[msg.sender] = true;
+    checkedInNow++;
+  }
 
-    /**
-     * Function that allows anyone to change the state variable "greeting" of the contract and increase the counters
-     *
-     * @param _newGreeting (string memory) - new greeting to save on the contract
-     */
-    function setGreeting(string memory _newGreeting) public payable {
-        // Print data to the hardhat chain console. Remove when deploying to a live network.
-        console.log("Setting new greeting '%s' from %s",  _newGreeting, msg.sender);
+  function checkout() public {
+    require(hasCheckedIn[msg.sender], "Not checked in");
+    hasCheckedIn[msg.sender] = false;
+    checkedInNow--;
 
-        // Change state variables
-        greeting = _newGreeting;
-        totalCounter += 1;
-        userGreetingCounter[msg.sender] += 1;
+    (bool success, ) = msg.sender.call{value: 0.001 ether}("");
+    require(success, "Failed to send Ether");
+  }
 
-        // msg.value: built-in global variable that represents the amount of ether sent with the transaction
-        if (msg.value > 0) {
-            premium = true;
-        } else {
-            premium = false;
-        }
+  /**
+   * Function that allows the owner to withdraw all the Ether in the contract
+   * The function can only be called by the owner of the contract as defined by the isOwner modifier
+   */
+  function rug() public isOwner {
+    (bool success, ) = owner.call{value: address(this).balance}("");
+    require(success, "Failed to send Ether");
+  }
 
-        // emit: keyword used to trigger an event
-        emit GreetingChange(msg.sender, _newGreeting, msg.value > 0, 0);
-    }
-
-    /**
-     * Function that allows the owner to withdraw all the Ether in the contract
-     * The function can only be called by the owner of the contract as defined by the isOwner modifier
-     */
-    function withdraw() isOwner public {
-        (bool success,) = owner.call{value: address(this).balance}("");
-        require(success, "Failed to send Ether");
-    }
-
-    /**
-     * Function that allows the contract to receive ETH
-     */
-    receive() external payable {}
+  /**
+   * Function that allows the contract to receive ETH
+   */
+  receive() external payable {}
 }

--- a/packages/nextjs/components/example-ui/ContractData.tsx
+++ b/packages/nextjs/components/example-ui/ContractData.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { useEffect, useRef, useState } from "react";
 import Marquee from "react-fast-marquee";
 import { useAnimationConfig, useScaffoldContractRead, useScaffoldEventSubscriber } from "~~/hooks/scaffold-eth";

--- a/packages/nextjs/components/example-ui/ContractInteraction.tsx
+++ b/packages/nextjs/components/example-ui/ContractInteraction.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { useState } from "react";
 import { CopyIcon } from "./assets/CopyIcon";
 import { DiamondIcon } from "./assets/DiamondIcon";

--- a/packages/nextjs/hooks/scaffold-eth/useScaffoldContractWrite.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useScaffoldContractWrite.ts
@@ -1,4 +1,5 @@
-import { useState } from "react";
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { useEffect, useState } from "react";
 import { Abi, ExtractAbiFunctionNames } from "abitype";
 import { utils } from "ethers";
 import { useContractWrite, useNetwork, usePrepareContractWrite } from "wagmi";
@@ -32,7 +33,7 @@ export const useScaffoldContractWrite = <
   const [isMining, setIsMining] = useState(false);
   const configuredNetwork = getTargetNetwork();
 
-  const { config, error } = usePrepareContractWrite({
+  const { config, error, refetch } = usePrepareContractWrite({
     chainId: configuredNetwork.id,
     address: deployedContractData?.address,
     abi: deployedContractData?.abi as Abi,

--- a/packages/nextjs/hooks/scaffold-eth/useScaffoldContractWrite.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useScaffoldContractWrite.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Abi, ExtractAbiFunctionNames } from "abitype";
 import { utils } from "ethers";
 import { useContractWrite, useNetwork, usePrepareContractWrite } from "wagmi";
@@ -22,9 +22,8 @@ export const useScaffoldContractWrite = <
   contractName,
   functionName,
   args,
+  // deps,
   value,
-  // @ts-expect-error
-  deps,
   ...writeConfig
 }: UseScaffoldWriteConfig<TContractName, TFunctionName>) => {
   const { data: deployedContractData } = useDeployedContractInfo(contractName);
@@ -33,8 +32,7 @@ export const useScaffoldContractWrite = <
   const [isMining, setIsMining] = useState(false);
   const configuredNetwork = getTargetNetwork();
 
-  // @ts-expect-error
-  const { config, refetch } = usePrepareContractWrite({
+  const { config, error } = usePrepareContractWrite({
     chainId: configuredNetwork.id,
     address: deployedContractData?.address,
     abi: deployedContractData?.abi as Abi,
@@ -43,6 +41,8 @@ export const useScaffoldContractWrite = <
     overrides: {
       value: value ? utils.parseEther(value) : undefined,
     },
+    cacheTime: 0,
+    staleTime: 0,
     ...writeConfig,
   });
 
@@ -50,9 +50,9 @@ export const useScaffoldContractWrite = <
     ...config,
   });
 
-  useEffect(() => {
-    refetch();
-  }, [deps]);
+  // useEffect(() => {
+  //   refetch();
+  // }, [deps]);
 
   const sendContractWriteTx = async () => {
     if (!deployedContractData) {
@@ -79,7 +79,7 @@ export const useScaffoldContractWrite = <
         setIsMining(false);
       }
     } else {
-      notification.error("Contract writer error. Try again.");
+      notification.error(getParsedEthersError(error));
       return;
     }
   };

--- a/packages/nextjs/hooks/scaffold-eth/useScaffoldContractWrite.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useScaffoldContractWrite.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import { useEffect, useState } from "react";
 import { Abi, ExtractAbiFunctionNames } from "abitype";
 import { utils } from "ethers";
@@ -23,7 +22,7 @@ export const useScaffoldContractWrite = <
   contractName,
   functionName,
   args,
-  // deps,
+  deps,
   value,
   ...writeConfig
 }: UseScaffoldWriteConfig<TContractName, TFunctionName>) => {
@@ -42,8 +41,6 @@ export const useScaffoldContractWrite = <
     overrides: {
       value: value ? utils.parseEther(value) : undefined,
     },
-    cacheTime: 0,
-    staleTime: 0,
     ...writeConfig,
   });
 
@@ -51,9 +48,9 @@ export const useScaffoldContractWrite = <
     ...config,
   });
 
-  // useEffect(() => {
-  //   refetch();
-  // }, [deps]);
+  useEffect(() => {
+    refetch();
+  }, [...(deps || []), refetch]);
 
   const sendContractWriteTx = async () => {
     if (!deployedContractData) {

--- a/packages/nextjs/hooks/scaffold-eth/useScaffoldContractWrite.ts
+++ b/packages/nextjs/hooks/scaffold-eth/useScaffoldContractWrite.ts
@@ -50,7 +50,8 @@ export const useScaffoldContractWrite = <
 
   useEffect(() => {
     refetch();
-  }, [...(deps || []), refetch]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [...(deps || [])]);
 
   const sendContractWriteTx = async () => {
     if (!deployedContractData) {

--- a/packages/nextjs/pages/example-ui.tsx
+++ b/packages/nextjs/pages/example-ui.tsx
@@ -12,6 +12,8 @@ const ExampleUI: NextPage = () => {
   const { writeAsync: checkoutFunc, isLoading: checkOutLoading } = useScaffoldContractWrite({
     contractName: "YourContract",
     functionName: "checkout",
+    // uncomment below to make it work
+    // deps: [data],
   });
   return (
     <>

--- a/packages/nextjs/pages/example-ui.tsx
+++ b/packages/nextjs/pages/example-ui.tsx
@@ -3,18 +3,20 @@ import type { NextPage } from "next";
 import { useScaffoldContractWrite } from "~~/hooks/scaffold-eth";
 
 const ExampleUI: NextPage = () => {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { writeAsync, isLoading, data } = useScaffoldContractWrite({
     contractName: "YourContract",
     functionName: "checkin",
     value: "0.001",
   });
+
+  console.log("⚡️ ~ file: example-ui.tsx:12 ~ data:", data);
+
   const { writeAsync: checkoutFunc, isLoading: checkOutLoading } = useScaffoldContractWrite({
     contractName: "YourContract",
     functionName: "checkout",
-    // uncomment below to make it work
-    // deps: [data],
+    deps: [data],
   });
+
   return (
     <>
       <Head>
@@ -29,9 +31,6 @@ const ExampleUI: NextPage = () => {
           className={`btn btn-primary ${isLoading ? "loading" : ""}`}
           onClick={async () => {
             await writeAsync();
-
-            // UnComment below to make it work
-            // await reConstructPrepare();
           }}
         >
           Checkin

--- a/packages/nextjs/pages/example-ui.tsx
+++ b/packages/nextjs/pages/example-ui.tsx
@@ -12,8 +12,6 @@ const ExampleUI: NextPage = () => {
   const { writeAsync: checkoutFunc, isLoading: checkOutLoading } = useScaffoldContractWrite({
     contractName: "YourContract",
     functionName: "checkout",
-    // uncomment below to make it work
-    // deps: [data],
   });
   return (
     <>

--- a/packages/nextjs/pages/example-ui.tsx
+++ b/packages/nextjs/pages/example-ui.tsx
@@ -1,9 +1,20 @@
 import Head from "next/head";
 import type { NextPage } from "next";
-import { ContractData } from "~~/components/example-ui/ContractData";
-import { ContractInteraction } from "~~/components/example-ui/ContractInteraction";
+import { useScaffoldContractWrite } from "~~/hooks/scaffold-eth";
 
 const ExampleUI: NextPage = () => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { writeAsync, isLoading, data } = useScaffoldContractWrite({
+    contractName: "YourContract",
+    functionName: "checkin",
+    value: "0.001",
+  });
+  const { writeAsync: checkoutFunc, isLoading: checkOutLoading } = useScaffoldContractWrite({
+    contractName: "YourContract",
+    functionName: "checkout",
+    // uncomment below to make it work
+    // deps: [data],
+  });
   return (
     <>
       <Head>
@@ -13,9 +24,24 @@ const ExampleUI: NextPage = () => {
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link href="https://fonts.googleapis.com/css2?family=Bai+Jamjuree&display=swap" rel="stylesheet" />
       </Head>
-      <div className="grid lg:grid-cols-2 flex-grow" data-theme="exampleUi">
-        <ContractInteraction />
-        <ContractData />
+      <div className=" flex flex-col space-y-4 items-center justify-center flex-grow" data-theme="exampleUi">
+        <button
+          className={`btn btn-primary ${isLoading ? "loading" : ""}`}
+          onClick={async () => {
+            await writeAsync();
+
+            // UnComment below to make it work
+            // await reConstructPrepare();
+          }}
+        >
+          Checkin
+        </button>
+        <button
+          className={`btn btn-primary ${checkOutLoading ? "loading" : ""}`}
+          onClick={async () => await checkoutFunc()}
+        >
+          CheckOut
+        </button>
       </div>
     </>
   );

--- a/packages/nextjs/utils/scaffold-eth/contract.ts
+++ b/packages/nextjs/utils/scaffold-eth/contract.ts
@@ -1,11 +1,6 @@
 import { Abi, AbiParametersToPrimitiveTypes, ExtractAbiEvent, ExtractAbiEventNames, ExtractAbiFunction } from "abitype";
 import type { ExtractAbiFunctionNames } from "abitype";
-import {
-  UseContractEventConfig,
-  UseContractReadConfig,
-  UseContractWriteConfig,
-  UsePrepareContractWriteConfig,
-} from "wagmi";
+import { UseContractEventConfig, UseContractReadConfig, UsePrepareContractWriteConfig } from "wagmi";
 import contractsData from "~~/generated/hardhat_contracts";
 import scaffoldConfig from "~~/scaffold.config";
 
@@ -29,7 +24,7 @@ type ContractsDeclaration = IsContractsFileMissing<GenericContractsDeclaration, 
 
 export type Chain = keyof ContractsDeclaration;
 
-type SelectedChainId = IsContractsFileMissing<number, (typeof scaffoldConfig)["targetNetwork"]["id"]>;
+type SelectedChainId = IsContractsFileMissing<number, typeof scaffoldConfig["targetNetwork"]["id"]>;
 
 type Contracts = ContractsDeclaration[SelectedChainId][0]["contracts"];
 
@@ -111,7 +106,7 @@ type WriteAbiStateMutability = "nonpayable" | "payable";
 
 type RestConfigParam<TAbiStateMutability extends AbiStateMutability> = Partial<
   Omit<
-    TAbiStateMutability extends ReadAbiStateMutability ? UseContractReadConfig : UseContractWriteConfig,
+    TAbiStateMutability extends ReadAbiStateMutability ? UseContractReadConfig : UsePrepareContractWriteConfig,
     "chainId" | "abi" | "address" | "functionName" | "args"
   >
 >;

--- a/packages/nextjs/utils/scaffold-eth/contract.ts
+++ b/packages/nextjs/utils/scaffold-eth/contract.ts
@@ -1,6 +1,11 @@
 import { Abi, AbiParametersToPrimitiveTypes, ExtractAbiEvent, ExtractAbiEventNames, ExtractAbiFunction } from "abitype";
 import type { ExtractAbiFunctionNames } from "abitype";
-import { UseContractEventConfig, UseContractReadConfig, UseContractWriteConfig } from "wagmi";
+import {
+  UseContractEventConfig,
+  UseContractReadConfig,
+  UseContractWriteConfig,
+  UsePrepareContractWriteConfig,
+} from "wagmi";
 import contractsData from "~~/generated/hardhat_contracts";
 import scaffoldConfig from "~~/scaffold.config";
 
@@ -143,9 +148,10 @@ export type UseScaffoldWriteConfig<
   TFunctionName extends ExtractAbiFunctionNames<ContractAbi<TContractName>, WriteAbiStateMutability>,
 > = {
   contractName: TContractName;
+  deps?: any[];
   value?: string;
 } & IsContractsFileMissing<
-  Partial<UseContractWriteConfig> & { args?: unknown[] },
+  Partial<UsePrepareContractWriteConfig> & { args?: unknown[] },
   {
     functionName: TFunctionName;
   } & UseScaffoldArgsParam<TContractName, WriteAbiStateMutability, TFunctionName> &


### PR DESCRIPTION
### Description : 
Had a discussion with Carlos about It and it would be great if we use prepareHook for useScaffoldContractWrite because check out https://github.com/scaffold-eth/se-2/issues/216#issuecomment-1450295130, also helps with [UX pitfalls](https://wagmi.sh/react/prepare-hooks#ux-pitfalls-without-prepare-hooks). 

### Previous problem with using `usePrepare` hook : 
Check out https://github.com/scaffold-eth/se-2/pull/215#issue-1601764822

### Current State of this PR : 
I have added the test contract same to https://github.com/scaffold-eth/se-2/pull/215#issue-1601764822, and updated with the solution mentioned below

### Solution : 
As suggested by Carlos, we are passing `deps` array based on which  we `refetch` the prepared config

TODO : 
- [ ] Test it properly
- [ ] Maybe mention in README.md about it? 

Suggestions are really welcome 🙌


