### PR TITLE
added screens in the tailwind config file

### DIFF
--- a/packages/nextjs/tailwind.config.js
+++ b/packages/nextjs/tailwind.config.js
@@ -112,6 +112,13 @@ module.exports = {
         "pulse-fast": "pulse 1s cubic-bezier(0.4, 0, 0.6, 1) infinite",
         zoom: "zoom 1s ease infinite",
       },
+      screens: {
+        sm: "640px", // => @media (min-width: 640px) { ... }
+        md: "768px", // => @media (min-width: 768px) { ... }
+        lg: "1024px", // => @media (min-width: 1024px) { ... }
+        xl: "1280px", // => @media (min-width: 1280px) { ... }
+        "2xl": "1536px", // => @media (min-width: 1536px) { ... }
+      },
     },
   },
 };


### PR DESCRIPTION
I noticed that "screens" were missing in the tailwind config file, I added various screen sizes that will help to easily create responsive UI easier and faster.

screens: {
        sm: "640px", // => @media (min-width: 640px) { ... }
        md: "768px", // => @media (min-width: 768px) { ... }
        lg: "1024px", // => @media (min-width: 1024px) { ... }
        xl: "1280px", // => @media (min-width: 1280px) { ... }
        "2xl": "1536px", // => @media (min-width: 1536px) { ... }
      },