### PR TITLE
chore: update `nextjs/.gitignore` to include base `.env` files

### DIFF
--- a/packages/nextjs/.gitignore
+++ b/packages/nextjs/.gitignore
@@ -26,6 +26,7 @@ yarn-error.log*
 .pnpm-debug.log*
 
 # local env files
+.env
 .env.local
 .env.development.local
 .env.test.local


### PR DESCRIPTION
Unless there's something I'm missing, a `.env` file should probably be gitignored in the `/nextjs` subproject/subpackage just like it is in the hardhat package.

This just adds `.env` to the `/nextjs` `.gitignore`. This can probably get rolled into another PR/cherry-picked by a maintainer if need be.