### PR TITLE
Fix re-render whole app on theme switch 

### DIFF
--- a/packages/nextjs/pages/_app.tsx
+++ b/packages/nextjs/pages/_app.tsx
@@ -1,10 +1,9 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import type { AppProps } from "next/app";
 import { RainbowKitProvider, darkTheme, lightTheme } from "@rainbow-me/rainbowkit";
 import "@rainbow-me/rainbowkit/styles.css";
 import NextNProgress from "nextjs-progressbar";
 import { Toaster } from "react-hot-toast";
-import { useDarkMode } from "usehooks-ts";
 import { WagmiConfig } from "wagmi";
 import { Footer } from "~~/components/Footer";
 import { Header } from "~~/components/Header";
@@ -18,9 +17,8 @@ import "~~/styles/globals.css";
 const ScaffoldEthApp = ({ Component, pageProps }: AppProps) => {
   const price = useEthPrice();
   const setEthPrice = useAppStore(state => state.setEthPrice);
-  // This variable is required for initial client side rendering of correct theme for RainbowKit
-  const [isDarkTheme, setIsDarkTheme] = useState(true);
-  const { isDarkMode } = useDarkMode();
+  // const isClient = useIsClient();
+  // const isDarkMode = useDarkMode();
 
   useEffect(() => {
     if (price > 0) {
@@ -28,17 +26,18 @@ const ScaffoldEthApp = ({ Component, pageProps }: AppProps) => {
     }
   }, [setEthPrice, price]);
 
-  useEffect(() => {
-    setIsDarkTheme(isDarkMode);
-  }, [isDarkMode]);
-
   return (
     <WagmiConfig client={wagmiClient}>
       <NextNProgress />
       <RainbowKitProvider
         chains={appChains.chains}
         avatar={BlockieAvatar}
-        theme={isDarkTheme ? darkTheme() : lightTheme()}
+        // theme={isClient && isDarkMode ? darkTheme() : lightTheme()}
+        // renders rainbowkit theme based on OS default theme
+        theme={{
+          lightMode: lightTheme(),
+          darkMode: darkTheme(),
+        }}
       >
         <div className="flex flex-col min-h-screen">
           <Header />


### PR DESCRIPTION
This PR might end up going to the trash, and this is just a suggestion/discussion: 

### Reason : 
I feel we should refrain from adding states that can be changed easily at the very top level of app like `_app` because changing them re-renders the whole app, and switching of theme causes the whole app to re-render feel a bit uncomfortable default to me and would delegate to end-user (**But this seems the only solution to keep rainbowkit theme inline with our app them**)

### Solution Proposed : 
 Use [Dark Mode support](https://www.rainbowkit.com/docs/theming#dark-mode-support) mentioned by rainbow kit which sets the rainbow kit theme based on OS default theme. 
 
 Advantage : 
 Solves the problem of re-rendering the whole app 

Disadvantage : 
It's independent of SE-2 theme and if the user selects the light se-2 theme he will still get the dark rainbowkit theme because of his OS preference. 

cc @sverps @damianmarti please free to suggest other options / directly close this 🙌 